### PR TITLE
쥬스 메이커 [STEP 1] Mason, Miro

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		87E360AE2962B4800099BCA2 /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E360AD2962B4800099BCA2 /* Fruit.swift */; };
+		87E360B02962BE400099BCA2 /* FruitJuice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E360AF2962BE400099BCA2 /* FruitJuice.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
@@ -20,6 +21,7 @@
 
 /* Begin PBXFileReference section */
 		87E360AD2962B4800099BCA2 /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
+		87E360AF2962BE400099BCA2 /* FruitJuice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitJuice.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -59,6 +61,7 @@
 				C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */,
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
 				87E360AD2962B4800099BCA2 /* Fruit.swift */,
+				87E360AF2962BE400099BCA2 /* FruitJuice.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -174,6 +177,7 @@
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
 				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
+				87E360B02962BE400099BCA2 /* FruitJuice.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,
 			);

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		87E360AE2962B4800099BCA2 /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E360AD2962B4800099BCA2 /* Fruit.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
@@ -18,6 +19,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		87E360AD2962B4800099BCA2 /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -56,6 +58,7 @@
 			children = (
 				C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */,
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
+				87E360AD2962B4800099BCA2 /* Fruit.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -167,6 +170,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				87E360AE2962B4800099BCA2 /* Fruit.swift in Sources */,
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
 				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		87B7DBC12965161400204EBF /* StockError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B7DBC02965161400204EBF /* StockError.swift */; };
 		87E360AE2962B4800099BCA2 /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E360AD2962B4800099BCA2 /* Fruit.swift */; };
 		87E360B02962BE400099BCA2 /* FruitJuice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E360AF2962BE400099BCA2 /* FruitJuice.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
@@ -20,6 +21,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		87B7DBC02965161400204EBF /* StockError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockError.swift; sourceTree = "<group>"; };
 		87E360AD2962B4800099BCA2 /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
 		87E360AF2962BE400099BCA2 /* FruitJuice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitJuice.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
@@ -62,6 +64,7 @@
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
 				87E360AD2962B4800099BCA2 /* Fruit.swift */,
 				87E360AF2962BE400099BCA2 /* FruitJuice.swift */,
+				87B7DBC02965161400204EBF /* StockError.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -174,6 +177,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				87E360AE2962B4800099BCA2 /* Fruit.swift in Sources */,
+				87B7DBC12965161400204EBF /* StockError.swift in Sources */,
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
 				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+final class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/JuiceMaker/JuiceMaker/Model/Fruit.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruit.swift
@@ -1,0 +1,16 @@
+//
+//  Fruit.swift
+//  JuiceMaker
+//
+//  Created by 김용재 on 2023/01/02.
+//
+
+import Foundation
+
+enum Fruit {
+    case strawberry
+    case banana
+    case pineapple
+    case kiwi
+    case mango
+}

--- a/JuiceMaker/JuiceMaker/Model/Fruit.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruit.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum Fruit {
+enum Fruit: CaseIterable {
     case strawberry
     case banana
     case pineapple

--- a/JuiceMaker/JuiceMaker/Model/FruitJuice.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitJuice.swift
@@ -1,0 +1,37 @@
+//
+//  FruitJuice.swift
+//  JuiceMaker
+//
+//  Created by 김용재 on 2023/01/02.
+//
+
+import Foundation
+
+enum FruitJuice {
+    case strawberry
+    case banana
+    case kiwi
+    case pineapple
+    case strawberryBanana
+    case mango
+    case mangoKiwi
+    
+    var recipe: [Fruit: Int] {
+        switch self {
+        case .strawberry:
+            return [.strawberry: 16]
+        case .banana:
+            return [.banana: 2]
+        case .kiwi:
+            return [.kiwi: 3]
+        case .pineapple:
+            return [.pineapple: 2]
+        case .strawberryBanana:
+            return [.strawberry: 10, .banana: 1]
+        case .mango:
+            return [.mango: 3]
+        case .mangoKiwi:
+            return [.mango: 2, .kiwi: 1]
+        }
+    }
+}

--- a/JuiceMaker/JuiceMaker/Model/FruitJuice.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitJuice.swift
@@ -19,19 +19,19 @@ enum FruitJuice {
     var recipe: [Fruit: Int] {
         switch self {
         case .strawberry:
-            return [.strawberry: 16]
+            return [Fruit.strawberry: 16]
         case .banana:
-            return [.banana: 2]
+            return [Fruit.banana: 2]
         case .kiwi:
-            return [.kiwi: 3]
+            return [Fruit.kiwi: 3]
         case .pineapple:
-            return [.pineapple: 2]
+            return [Fruit.pineapple: 2]
         case .strawberryBanana:
-            return [.strawberry: 10, .banana: 1]
+            return [Fruit.strawberry: 10, Fruit.banana: 1]
         case .mango:
-            return [.mango: 3]
+            return [Fruit.mango: 3]
         case .mangoKiwi:
-            return [.mango: 2, .kiwi: 1]
+            return [Fruit.mango: 2, Fruit.kiwi: 1]
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -10,6 +10,12 @@ import Foundation
 class FruitStore {
     private(set) var stock: [Fruit: Int] = [:]
     
+    init() {
+        Fruit.allCases.forEach { fruit in
+            stock[fruit] = 10
+        }
+    }
+    
     func changeStock(of fruit: Fruit, by number: Int) {
         guard let result = stock[fruit] else {
             return

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -16,12 +16,12 @@ final class FruitStore {
         }
     }
     
-    func changeStock(of fruit: Fruit, by number: Int) {
+    func changeStock(of fruit: Fruit, by number: Int) throws {
         guard let fruitStock = stock[fruit] else {
-            return print("해당하는 과일이 존재하지 않습니다.")
+            throw StockError.noCorrespondingFruit
         }
         guard fruitStock + number >= 0 else {
-            return print("재고가 부족합니다.")
+            throw StockError.notEnoughToChange
         }
         
         stock[fruit] = fruitStock + number

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 // 과일 저장소 타입
-class FruitStore {
+final class FruitStore {
     private(set) var stock: [Fruit: Int] = [:]
     
     init() {

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -20,7 +20,7 @@ class FruitStore {
         guard let result = stock[fruit] else {
             return print("해당하는 과일이 존재하지 않습니다.")
         }
-        guard result + number > 0 else {
+        guard result + number >= 0 else {
             return print("재고가 부족합니다.")
         }
         

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -18,7 +18,10 @@ class FruitStore {
     
     func changeStock(of fruit: Fruit, by number: Int) {
         guard let result = stock[fruit] else {
-            return
+            return print("해당하는 과일이 존재하지 않습니다.")
+        }
+        guard result + number > 0 else {
+            return print("재고가 부족합니다.")
         }
         
         stock[fruit] = result + number

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -9,4 +9,12 @@ import Foundation
 // 과일 저장소 타입
 class FruitStore {
     private(set) var stock: [Fruit: Int] = [:]
+    
+    func changeStock(of fruit: Fruit, by number: Int) {
+        guard let result = stock[fruit] else {
+            return
+        }
+        
+        stock[fruit] = result + number
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -17,13 +17,13 @@ class FruitStore {
     }
     
     func changeStock(of fruit: Fruit, by number: Int) {
-        guard let result = stock[fruit] else {
+        guard let fruitStock = stock[fruit] else {
             return print("해당하는 과일이 존재하지 않습니다.")
         }
-        guard result + number >= 0 else {
+        guard fruitStock + number >= 0 else {
             return print("재고가 부족합니다.")
         }
         
-        stock[fruit] = result + number
+        stock[fruit] = fruitStock + number
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -8,5 +8,5 @@ import Foundation
 
 // 과일 저장소 타입
 class FruitStore {
-    
+    private(set) var stock: [Fruit: Int] = [:]
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -21,11 +21,8 @@ struct JuiceMaker {
     }
     
     private func hasEnoughStock(for fruitJuice: FruitJuice) -> Bool {
-        fruitJuice.recipe.allSatisfy { fruit, numberOfUse in
-            guard let fruitStock = fruitStore.stock[fruit] else {
-                return false
-            }
-            return fruitStock >= numberOfUse
+        return fruitJuice.recipe.allSatisfy { fruit, numberOfUse in
+            (fruitStore.stock[fruit] ?? 0) >= numberOfUse
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -10,13 +10,13 @@ import Foundation
 struct JuiceMaker {
     private let fruitStore = FruitStore()
     
-    func makeJuice(of fruitJuice: FruitJuice) {
+    func makeJuice(of fruitJuice: FruitJuice) throws {
         guard hasEnoughStock(for: fruitJuice) else {
-            return print("쥬스를 만들기 위한 재고가 부족합니다.")
+            throw StockError.notEnoughToMakeJuice
         }
         
-        fruitJuice.recipe.forEach { fruit, numberOfUse in
-            fruitStore.changeStock(of: fruit, by: -numberOfUse)
+        try fruitJuice.recipe.forEach { fruit, numberOfUse in
+            try fruitStore.changeStock(of: fruit, by: -numberOfUse)
         }
     }
     

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -11,8 +11,21 @@ struct JuiceMaker {
     private let fruitStore = FruitStore()
     
     func makeJuice(of fruitJuice: FruitJuice) {
+        guard hasEnoughStock(for: fruitJuice) else {
+            return print("쥬스를 만들기 위한 재고가 부족합니다.")
+        }
+        
         fruitJuice.recipe.forEach { fruit, numberOfUse in
             fruitStore.changeStock(of: fruit, by: -numberOfUse)
+        }
+    }
+    
+    private func hasEnoughStock(for fruitJuice: FruitJuice) -> Bool {
+        fruitJuice.recipe.allSatisfy { fruit, numberOfUse in
+            guard let fruitStock = fruitStore.stock[fruit] else {
+                return false
+            }
+            return fruitStock >= numberOfUse
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -8,5 +8,11 @@ import Foundation
 
 // 쥬스 메이커 타입
 struct JuiceMaker {
+    private let fruitStore = FruitStore()
     
+    func makeJuice(of fruitJuice: FruitJuice) {
+        fruitJuice.recipe.forEach { fruit, numberOfUse in
+            fruitStore.changeStock(of: fruit, by: -numberOfUse)
+        }
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/StockError.swift
+++ b/JuiceMaker/JuiceMaker/Model/StockError.swift
@@ -1,0 +1,25 @@
+//
+//  StockError.swift
+//  JuiceMaker
+//
+//  Created by 김용재 on 2023/01/04.
+//
+
+import Foundation
+
+enum StockError: LocalizedError {
+    case noCorrespondingFruit
+    case notEnoughToMakeJuice
+    case notEnoughToChange
+    
+    var errorDescription: String? {
+        switch self {
+        case .noCorrespondingFruit:
+            return "일치하는 과일이 없습니다."
+        case .notEnoughToMakeJuice:
+            return "쥬스를 만들기에 재고가 부족합니다."
+        case .notEnoughToChange:
+            return "수량을 변경하기에 재고가 충분하지 않습니다."
+        }
+    }
+}


### PR DESCRIPTION
안녕하세요 제이슨!🙋‍♂️ @ehgud0670 
쥬스메이커 프로젝트를 진행하게 된 Mason, Miro 입니다 :)
어느덧 2023년 새해가 밝았네요ㅎㅎ 
프로젝트를 해 나가며 리뷰어 분들의 코드리뷰를 통해 정말 큰 도움이 되고 있습니다🤗
이번 프로젝트를 통해 "이유 있는 코드"를 작성하는 습관을 들일 수 있도록 열심히 고민하고 공부하겠습니다! :+1: (많은 도움 부탁드려요..💕)
감사합니다🙇‍♂️


# ✅ 요구사항 & 체크리스트

- [x]  `FruitStore` 타입 정의 - 과일의 재고를 관리
    - [x]  딸기, 바나나, 파인애플, 키위, 망고 종류의 과일을 관리 (초기 재고 10개)
    - [x]  각 과일의 수량 n개를 변경하는 기능 구현
- [x]  `JuiceMaker` 타입 정의 - 과일쥬스를 제조
    - [x]  각 쥬스별 제조 레시피 정의 (ex 딸기쥬스 - 딸기 16개 소모…)
    - [x]  `FruitStore`의 과일을 사용하여 과일쥬스를 제조하는 기능 구현
    - [x]  쥬스 제작 전 과일의 재고를 확인하는 로직 구현

# 📝 모델 구조

`struct JuiceMaker` -  쥬스를 제조하는 쥬스메이커

- `let fruitStore: FruitStore` - 쥬스 제조 시 과일의 재고를 관리
- `func makeJuice(of fruitJuice: FruitJuice)` - 재고 확인 후, 과일 쥬스 제조
- `fun hasEnoughStock(for fruitJuice: FruitJuice)` - 쥬스 레시피를 통한 재고 확인

`class FruitStore` - 과일의 재고를 관리

- `var stock: [Fruit: Int]` - 각 과일 타입별 재고 수량을 갖고있는 딕셔너리
- `func changeStock(of fruit: Fruit, by number: Int)` - 과일 재고의 수량을 변경

`enum Fruit` - 과일의 종류를 담고 있는 enum

`enum FruitJuice` - 과일 쥬스의 종류를 담고 있는 enum

- `var recipe: [Fruit: Int]` - 각 과일 쥬스별 레시피 정보 (소모 과일 갯수)

# **⁉️ 고민과 해결**

### 😲 1. 클래스, 구조체 중 어떤 걸 선택해야 할까? (FruitStore, JuiceMaker)

- `FruitStore`
    - 내부에 과일 재고에 해당하는 딕셔너리 데이터를 갖고 있고, 해당 데이터를 수정하는 역할을 수행합니다
    - 데이터를 갖고 있고, 계속해서 해당 데이터를 수정해야 하며 해당 데이터의 identity 를 유지해야 한다면`class` 로 구현하는 것이 적절하다 생각되었습니다.
    - +) 차후 여러 뷰컨트롤러에서 전역적인 접근이 가능하고 과일 재고 데이터를 공유해야 하는 상황이 생긴다면 싱글턴 패턴으로 구현하는 것이 바람직 해 보였습니다.
- `JuiceMaker`
    - 쥬스를 만드는 역할을 하고, 실질적인 속성(과일 재고)에 대한 변경은 `FruitStore` 에게 위임하므로 구조체로 구현하는 것이 적절하다 판단했습니다.

### 🤔 2. `enum Fruit` 와 `enum FruitJuice` 의 case 명이 겹치는 문제

- 과일 종류에 해당하는 Fruit 의 case 와 과일 쥬스 종류에 해당하는 FruitJuice case 중 
딸기 - 딸기(쥬스), 바나나 - 바나나(쥬스) 처럼 동일한 case 명을 공유합니다.
- 두 가지의 enum 을 동시에 사용할 때, enum의 타입을 축약해 case 만 작성할 시 식별이 불가한 문제가 생겼고 이에 대한 해결책을 생각 해 보았습니다.
    1. FruitJuice의 case 이름을 .strawberryJuice 로 쥬스라는 걸 명시해준다
    2. 동시에 사용하는 경우, 한 쪽의 enum을 Fruit.strawberry 로 풀어쓴다
- 1번의 경우에는, FruitJuice.strawberryJuice 처럼 타입명에 명시된 “Juice” 가 케이스에도 중복되는 느낌이 들어서 2번으로 구현하였습니다.

❓🧐 이에 대한 제이슨의 의견은 어떤지 여쭤보고 싶습니다..! 


```swift
enum Fruit: CaseIterable {
    case strawberry
    case banana ...

enum FruitJuice {
    case strawberry
    case banana
    case strawberryBanana ...
    var recipe: [Fruit: Int] {
        switch self {
        case .strawberry: 
            return [Fruit.strawberry: 16]  // 🤔 둘 다 case 명이 strawberry 이다...
        case .banana:
            return [Fruit.banana: 2]
  ...
```


### 😲 3. `.allSatisfy` 내부에서 옵셔널 바인딩 처리

- 재고 수량이 충분한지 확인하는 hasEnoughStock 함수를 사용할 때,
전체 조건을 확인하는 `.allSatisfy` 의 내부에서 어떻게 옵셔널 바인딩을 처리 할 것인가?
- `.allSatisfy` 클로저 내부에서 작성하는 return 은 함수의 return 이 아니라, 
파라미터로 받는 조건을 체크하는 클로저의 return 이므로, 각기 return 으로 처리 가능
    - `func allSatisfy(_ predicate: (Self.Element) throws -> Bool) rethrows -> Bool`

```swift
private func hasEnoughStock(for fruitJuice: FruitJuice) -> Bool {
    return fruitJuice.recipe.allSatisfy { fruit, numberOfUse in
        guard let fruitStock = fruitStore.stock[fruit] else {
            return false
        }
        return fruitStock >= numberOfUse
    }
}
```

- 더욱 간단하게, 이번 경우에는 수량을 체크하는 것이므로 해당 dictionary가 nil 일 경우에는 재고 수량을 0으로 nil coalescing 기본값을 줘도 된다고 판단하여 그렇게 처리했습니다.

```swift
private func hasEnoughStock(for fruitJuice: FruitJuice) -> Bool {
    return fruitJuice.recipe.allSatisfy { fruit, numberOfUse in
        (fruitStore.stock[fruit] ?? 0) >= numberOfUse
    }
}
```

### 🤔 4. `changeStock(of:by:)` 함수의 파라미터에 대한 고민

- 아래 코드와 같이 `makeJuice(of:)` 함수에서 `changeStock(of:by:)` 함수 호출을 통하여 과일의 재고를 변경시킵니다. 
- 이 과정에서 `changeStock(of:by:)` 함수는 `makeJuice(of:)` 함수 안에서 `-numberOfUse`를 파라미터 값으로 받게 되는데, 파라미터에 “-”를 붙이는 게 어색하다고 느껴져 고민을 하게 되었습니다. 
해당 부분을 보완하기 위하여 아래와 같은 방안을 생각해보았습니다. 
    - 재고 수정 함수`changeStock(of:by:)`를 두개의 함수로 나누기(재고 추가, 재고 사용)
    - `changeStock(of:by:)` 함수에 재고 추가(+), 재고 사용(-) 여부를 판단하는 파라미터를 추가하기

❓🧐 이러한 고민에대해 Jason의 의견이 궁금합니다! 더 좋은 방식이 있을 지 혹은 해당 고민보다는 다른 코드에 더 힘을 쓰는(?)게 좋을 지 궁금합니다! 

```swift
// struct **JuiceMaker**
func makeJuice(of fruitJuice: FruitJuice) {
    guard hasEnoughStock(for: fruitJuice) else {
        return print("쥬스를 만들기 위한 재고가 부족합니다.")
    }
    
    fruitJuice.recipe.forEach { fruit, numberOfUse in
                                    // 🤔 해당 부분에 "-" 사용
        fruitStore.changeStock(of: fruit, by: -numberOfUse)    
    }
}

// class **FruitStore**
func changeStock(of fruit: Fruit, by number: Int) {
    guard let fruitStock = stock[fruit] else {
        return print("해당하는 과일이 존재하지 않습니다.")
    }
    guard fruitStock + number >= 0 else {
        return print("재고가 부족합니다.")
    }

    stock[fruit] = fruitStock + number
}
```

### 😲 5. `CaseIterable` 프로토콜 채택을 통한 `Fruit.allCases` 사용

- `FruitStore` 객체 생성 시 initializer를 통하여 `FruitStore` 프로퍼티 stock의 기본 재고값을 `[Fruit:Int]`로 각 과일별로 10개만큼 채워 넣기 위하여 `allCases` 메소드를 사용하려고 하였습니다.
- 이와 관련하여 공부를 하던 중, 열거형 타입을 배열처럼 사용하기위해서는 `CaseIterable` 프로토콜을 채택해야 됨을 알게되었고, 해당 프로토콜 채택을 통하여 손쉽게 initialize를 시킬 수 있었습니다.

```swift
final class FruitStore {
    private(set) var stock: [Fruit: Int] = [:]
    
    init() {
        Fruit.**allCases**.forEach { fruit in
            stock[fruit] = 10
        }
    }
}
```

## 🤔 질문사항 정리
직접 여쭤보고 싶은 질문은 아래와 같이 두가지입니다! (위의 "고민과 해결"에서 서술)
2. `enum Fruit` 와 `enum FruitJuice` 의 case 명이 겹치는 문제
4. `changeStock(of:by:)` 함수의 파라미터에 대한 고민

감사합니다!