### PR TITLE
쥬스메이커 [STEP 1] Avery, Jenna

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,48 @@
+# Created by https://www.toptal.com/developers/gitignore/api/swift,macos,cocoapods,swiftpackagemanager
+# Edit at https://www.toptal.com/developers/gitignore?templates=swift,macos,cocoapods,swiftpackagemanager
+
+### CocoaPods ###
+## CocoaPods GitIgnore Template
+
+# CocoaPods - Only use to conserve bandwidth / Save time on Pushing
+#           - Also handy if you have a large number of dependant pods
+#           - AS PER https://guides.cocoapods.org/using/using-cocoapods.html NEVER IGNORE THE LOCK FILE
+Pods/
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Swift ###
 # Xcode
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
@@ -35,13 +80,11 @@ timeline.xctimeline
 playground.xcworkspace
 
 # Swift Package Manager
-#
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
 # Package.pins
 # Package.resolved
 # *.xcodeproj
-#
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
 # hence it is not needed unless you have added a package configuration file to your project
 # .swiftpm
@@ -49,18 +92,14 @@ playground.xcworkspace
 .build/
 
 # CocoaPods
-#
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
-#
 # Pods/
-#
 # Add this line if you want to avoid checking in source code from the Xcode workspace
 # *.xcworkspace
 
 # Carthage
-#
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
 # Carthage/Checkouts
 
@@ -71,7 +110,6 @@ Dependencies/
 .accio/
 
 # fastlane
-#
 # It is recommended to not store the screenshots in the git repo.
 # Instead, use fastlane to re-generate the screenshots whenever they are needed.
 # For more information about the recommended setup visit:
@@ -83,8 +121,15 @@ fastlane/screenshots/**/*.png
 fastlane/test_output
 
 # Code Injection
-#
 # After new code Injection tools there's a generated folder /iOSInjectionProject
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+### SwiftPackageManager ###
+Packages
+xcuserdata
+*.xcodeproj
+
+
+# End of https://www.toptal.com/developers/gitignore/api/swift,macos,cocoapods,swiftpackagemanager

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3B7BD54229640C4A00023831 /* Fruits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7BD54129640C4A00023831 /* Fruits.swift */; };
+		3B7BD5442964103300023831 /* Juice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7BD5432964103300023831 /* Juice.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
@@ -18,6 +20,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3B7BD54129640C4A00023831 /* Fruits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruits.swift; sourceTree = "<group>"; };
+		3B7BD5432964103300023831 /* Juice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Juice.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -56,6 +60,8 @@
 			children = (
 				C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */,
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
+				3B7BD54129640C4A00023831 /* Fruits.swift */,
+				3B7BD5432964103300023831 /* Juice.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -169,6 +175,8 @@
 			files = (
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
 				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
+				3B7BD5442964103300023831 /* Juice.swift in Sources */,
+				3B7BD54229640C4A00023831 /* Fruits.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -11,8 +11,7 @@ import Foundation
 /// singleton 적용하기
 
 class FruitStore {
-    
-    static var shared = FruitStore()
+    static var shared = FruitStore(defaultStock: 10)
     
     // TODO:- 열거형들 재고 딕셔너리 만들기 [key: value] = [fruit: Int]
     enum Fruits: CaseIterable {
@@ -22,6 +21,8 @@ class FruitStore {
         case pineapples
         case mangos
     }
+    
+    var overallStock = [Fruits: Int]()
     
     // 재고 확인용
     func checkStock() {}
@@ -33,6 +34,7 @@ class FruitStore {
     func decrease() {}
     
     // TODO:- init에 기본값 넣기, 10개씩 초기화
-    private init() {}
-    
+    private init(defaultStock: Int) {
+        Fruits.allCases.forEach { overallStock[$0] = defaultStock }
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -30,11 +30,11 @@ class FruitStore {
         return stock
     }
     
-    // 과일 재고 n개 증가
-    func increase() {}
-    
     // 과일 재고 n개 감소
-    func decrease() {}
+    func decrease(of fruit: Fruits, amount: Int) {
+        guard let stock = overallStock[fruit] else { return }
+        overallStock.updateValue(stock - amount, forKey: fruit)
+    }
     
     // TODO:- init에 기본값 넣기, 10개씩 초기화
     private init(defaultStock: Int) {

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -7,10 +7,10 @@
 import Foundation
 
 // 과일 저장소 타입
-class FruitStore {
-    static var shared = FruitStore(initialStock: 10)
+final class FruitStore {
+    static let shared = FruitStore(initialStock: 10)
     
-    var stocks = [Fruits: Int]()
+    private var stocks = [Fruits: Int]()
     
     func count(of fruit: Fruits) -> Int {
         guard let stock = stocks[fruit] else { return 0 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -8,7 +8,7 @@ import Foundation
 
 // 과일 저장소 타입
 class FruitStore {
-    static var shared = FruitStore(initiallStock: 10)
+    static var shared = FruitStore(initialStock: 10)
     
     var stocks = [Fruits: Int]()
     
@@ -22,7 +22,7 @@ class FruitStore {
         stocks.updateValue(stock - amount, forKey: fruit)
     }
     
-    private init(initiallStock: Int) {
-        Fruits.allCases.forEach { stocks[$0] = initiallStock }
+    private init(initialStock: Int) {
+        Fruits.allCases.forEach { stocks[$0] = initialStock }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -7,13 +7,10 @@
 import Foundation
 
 // 과일 저장소 타입
-
-/// singleton 적용하기
-
 class FruitStore {
-    static var shared = FruitStore(defaultStock: 10)
     
-    // TODO:- 열거형들 재고 딕셔너리 만들기 [key: value] = [fruit: Int]
+    static var shared = FruitStore(initiallStock: 10)
+    
     enum Fruits: CaseIterable {
         case strawberries
         case bananas
@@ -22,22 +19,19 @@ class FruitStore {
         case mangos
     }
     
-    var overallStock = [Fruits: Int]()
+    var stocks = [Fruits: Int]()
     
-    // 재고 확인용
-    func checkStock(of fruit: Fruits) -> Int {
-        guard let stock = overallStock[fruit] else { return 0 }
+    func countStock(of fruit: Fruits) -> Int {
+        guard let stock = stocks[fruit] else { return 0 }
         return stock
     }
     
-    // 과일 재고 n개 감소
     func decrease(of fruit: Fruits, amount: Int) {
-        guard let stock = overallStock[fruit] else { return }
-        overallStock.updateValue(stock - amount, forKey: fruit)
+        guard let stock = stocks[fruit] else { return }
+        stocks.updateValue(stock - amount, forKey: fruit)
     }
     
-    // TODO:- init에 기본값 넣기, 10개씩 초기화
-    private init(defaultStock: Int) {
-        Fruits.allCases.forEach { overallStock[$0] = defaultStock }
+    private init(initiallStock: Int) {
+        Fruits.allCases.forEach { stocks[$0] = initiallStock }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -12,7 +12,7 @@ class FruitStore {
     
     var stocks = [Fruits: Int]()
     
-    func countStock(of fruit: Fruits) -> Int {
+    func count(of fruit: Fruits) -> Int {
         guard let stock = stocks[fruit] else { return 0 }
         return stock
     }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -25,7 +25,10 @@ class FruitStore {
     var overallStock = [Fruits: Int]()
     
     // 재고 확인용
-    func checkStock() {}
+    func checkStock(of fruit: Fruits) -> Int {
+        guard let stock = overallStock[fruit] else { return 0 }
+        return stock
+    }
     
     // 과일 재고 n개 증가
     func increase() {}

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -8,16 +8,7 @@ import Foundation
 
 // 과일 저장소 타입
 class FruitStore {
-    
     static var shared = FruitStore(initiallStock: 10)
-    
-    enum Fruits: CaseIterable {
-        case strawberries
-        case bananas
-        case kiwis
-        case pineapples
-        case mangos
-    }
     
     var stocks = [Fruits: Int]()
     

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -7,6 +7,32 @@
 import Foundation
 
 // 과일 저장소 타입
+
+/// singleton 적용하기
+
 class FruitStore {
+    
+    static var shared = FruitStore()
+    
+    // TODO:- 열거형들 재고 딕셔너리 만들기 [key: value] = [fruit: Int]
+    enum Fruits: CaseIterable {
+        case strawberries
+        case bananas
+        case kiwis
+        case pineapples
+        case mangos
+    }
+    
+    // 재고 확인용
+    func checkStock() {}
+    
+    // 과일 재고 n개 증가
+    func increase() {}
+    
+    // 과일 재고 n개 감소
+    func decrease() {}
+    
+    // TODO:- init에 기본값 넣기, 10개씩 초기화
+    private init() {}
     
 }

--- a/JuiceMaker/JuiceMaker/Model/Fruits.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruits.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 enum Fruits: CaseIterable {
-    case strawberries
-    case bananas
-    case kiwis
-    case pineapples
-    case mangos
+    case strawberry
+    case banana
+    case kiwi
+    case pineapple
+    case mango
 }

--- a/JuiceMaker/JuiceMaker/Model/Fruits.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruits.swift
@@ -1,0 +1,16 @@
+//
+//  Fruits.swift
+//  JuiceMaker
+//
+//  Created by J.E on 2023/01/03.
+//
+
+import Foundation
+
+enum Fruits: CaseIterable {
+    case strawberries
+    case bananas
+    case kiwis
+    case pineapples
+    case mangos
+}

--- a/JuiceMaker/JuiceMaker/Model/Juice.swift
+++ b/JuiceMaker/JuiceMaker/Model/Juice.swift
@@ -1,0 +1,41 @@
+//
+//  Juice.swift
+//  JuiceMaker
+//
+//  Created by J.E on 2023/01/03.
+//
+
+import Foundation
+
+enum Juice: String {
+    case strawberry = "딸기"
+    case banana = "바나나"
+    case kiwi = "키위"
+    case pineapple = "파인애플"
+    case strawberryBanana = "딸바"
+    case mango = "망고"
+    case mangoKiwi = "망키"
+    
+    var orderTitle: String {
+        return self.rawValue + "쥬스 주문"
+    }
+    
+    var recipe: [Fruits: Int] {
+        switch self {
+        case .strawberry:
+            return [.strawberries: 16]
+        case .banana:
+            return [.bananas: 2]
+        case .kiwi:
+            return [.kiwis: 3]
+        case .pineapple:
+            return [.pineapples: 2]
+        case .strawberryBanana:
+            return [.strawberries: 10, .bananas: 1]
+        case .mango:
+            return [.mangos: 3]
+        case .mangoKiwi:
+            return [.mangos: 2, .kiwis: 1]
+        }
+    }
+}

--- a/JuiceMaker/JuiceMaker/Model/Juice.swift
+++ b/JuiceMaker/JuiceMaker/Model/Juice.swift
@@ -23,19 +23,19 @@ enum Juice: String {
     var recipe: [Fruits: Int] {
         switch self {
         case .strawberry:
-            return [.strawberries: 16]
+            return [.strawberry: 16]
         case .banana:
-            return [.bananas: 2]
+            return [.banana: 2]
         case .kiwi:
-            return [.kiwis: 3]
+            return [.kiwi: 3]
         case .pineapple:
-            return [.pineapples: 2]
+            return [.pineapple: 2]
         case .strawberryBanana:
-            return [.strawberries: 10, .bananas: 1]
+            return [.strawberry: 10, .banana: 1]
         case .mango:
-            return [.mangos: 3]
+            return [.mango: 3]
         case .mangoKiwi:
-            return [.mangos: 2, .kiwis: 1]
+            return [.mango: 2, .kiwi: 1]
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -10,9 +10,10 @@ import Foundation
 struct JuiceMaker {
     private let fruitStore = FruitStore.shared
     
-    private func checkOrderable(of ingredients: [Fruits: Int]) -> Bool {
+    private func checkOrderable(of menu: Juice) -> Bool {
+        let ingredients = menu.recipe
         for ingredient in ingredients {
-            let eachStock = fruitStore.countStock(of: ingredient.key)
+            let eachStock = fruitStore.count(of: ingredient.key)
             guard eachStock >= ingredient.value else { return false }
         }
         return true

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -10,7 +10,9 @@ import Foundation
 struct JuiceMaker {
     
     private let fruitStore = FruitStore.shared
-    
+
+    typealias Ingredients = [FruitStore.Fruits: Int]
+
     enum Juice {
         case strawberry
         case banana
@@ -39,7 +41,7 @@ struct JuiceMaker {
             }
         }
         
-        var receipe: [FruitStore.Fruits: Int] {
+        var receipe: Ingredients {
             switch self {
             case .strawberry:
                 return [.strawberries: 16]
@@ -60,8 +62,16 @@ struct JuiceMaker {
         
     }
     
+    func checkOrderable(of ingredients: Ingredients) -> Bool {
+        for ingredient in ingredients {
+            let eachStock = fruitStore.checkStock(of: ingredient.key)
+            guard eachStock >= ingredient.value else { return false }
+        }
+        return true
+    }
+    
     // 쥬스 제조 -> 과일 저장소 재고 확인을 먼저하고, 재고 감소를 호출함
-    func startBlending () {
+    func startBlending() {
         //fruitStore.checkStock() //쥬스 종류에 따라 매개변수 입력 (분기처리)
         fruitStore.decrease()
     }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -9,4 +9,24 @@ import Foundation
 // 쥬스 메이커 타입
 struct JuiceMaker {
     
+    private let fruitStore = FruitStore.shared
+    
+    enum Juice {
+        case strawberry
+        case banana
+        case kiwi
+        case pineapple
+        case strawberryBanana
+        case mango
+        case mangoKiwi
+        
+        // TODO:- 레시피 적기(과일 필요한 개수)
+        
+    }
+    
+    // 쥬스 제조 -> 과일 저장소 재고 확인을 먼저하고, 재고 감소를 호출함
+    func startBlending () {
+        fruitStore.decrease()
+    }
+    
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -26,6 +26,7 @@ struct JuiceMaker {
     
     // 쥬스 제조 -> 과일 저장소 재고 확인을 먼저하고, 재고 감소를 호출함
     func startBlending () {
+        //fruitStore.checkStock() //쥬스 종류에 따라 매개변수 입력 (분기처리)
         fruitStore.decrease()
     }
     

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -20,7 +20,43 @@ struct JuiceMaker {
         case mango
         case mangoKiwi
         
-        // TODO:- 레시피 적기(과일 필요한 개수)
+        var name: String {
+            switch self {
+            case .strawberry:
+                return "딸기쥬스"
+            case .banana:
+                return "바나나쥬스"
+            case .kiwi:
+                return "키위쥬스"
+            case .pineapple:
+                return "파인애플쥬스"
+            case .strawberryBanana:
+                return "딸바쥬스"
+            case .mango:
+                return "망고쥬스"
+            case .mangoKiwi:
+                return "망키쥬스"
+            }
+        }
+        
+        var receipe: [FruitStore.Fruits: Int] {
+            switch self {
+            case .strawberry:
+                return [.strawberries: 16]
+            case .banana:
+                return [.bananas: 2]
+            case .kiwi:
+                return [.kiwis: 3]
+            case .pineapple:
+                return [.pineapples: 2]
+            case .strawberryBanana:
+                return [.strawberries: 10, .bananas: 1]
+            case .mango:
+                return [.mangos: 3]
+            case .mangoKiwi:
+                return [.mangos: 2, .kiwis: 1]
+            }
+        }
         
     }
     

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -71,9 +71,10 @@ struct JuiceMaker {
     }
     
     // 쥬스 제조 -> 과일 저장소 재고 확인을 먼저하고, 재고 감소를 호출함
-    func startBlending() {
-        //fruitStore.checkStock() //쥬스 종류에 따라 매개변수 입력 (분기처리)
-        fruitStore.decrease()
+    func startBlending(of juice: Juice) {
+        juice.receipe.forEach {
+            fruitStore.decrease(of: $0.key, amount: $0.value)
+        }
     }
     
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -62,19 +62,17 @@ struct JuiceMaker {
         
     }
     
-    func checkOrderable(of ingredients: Ingredients) -> Bool {
+    private func checkOrderable(of ingredients: Ingredients) -> Bool {
         for ingredient in ingredients {
-            let eachStock = fruitStore.checkStock(of: ingredient.key)
+            let eachStock = fruitStore.countStock(of: ingredient.key)
             guard eachStock >= ingredient.value else { return false }
         }
         return true
     }
     
-    // 쥬스 제조 -> 과일 저장소 재고 확인을 먼저하고, 재고 감소를 호출함
-    func startBlending(of juice: Juice) {
+    private func startBlending(of juice: Juice) {
         juice.receipe.forEach {
             fruitStore.decrease(of: $0.key, amount: $0.value)
         }
     }
-    
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -8,61 +8,9 @@ import Foundation
 
 // 쥬스 메이커 타입
 struct JuiceMaker {
-    
     private let fruitStore = FruitStore.shared
-
-    typealias Ingredients = [FruitStore.Fruits: Int]
-
-    enum Juice {
-        case strawberry
-        case banana
-        case kiwi
-        case pineapple
-        case strawberryBanana
-        case mango
-        case mangoKiwi
-        
-        var name: String {
-            switch self {
-            case .strawberry:
-                return "딸기쥬스"
-            case .banana:
-                return "바나나쥬스"
-            case .kiwi:
-                return "키위쥬스"
-            case .pineapple:
-                return "파인애플쥬스"
-            case .strawberryBanana:
-                return "딸바쥬스"
-            case .mango:
-                return "망고쥬스"
-            case .mangoKiwi:
-                return "망키쥬스"
-            }
-        }
-        
-        var receipe: Ingredients {
-            switch self {
-            case .strawberry:
-                return [.strawberries: 16]
-            case .banana:
-                return [.bananas: 2]
-            case .kiwi:
-                return [.kiwis: 3]
-            case .pineapple:
-                return [.pineapples: 2]
-            case .strawberryBanana:
-                return [.strawberries: 10, .bananas: 1]
-            case .mango:
-                return [.mangos: 3]
-            case .mangoKiwi:
-                return [.mangos: 2, .kiwis: 1]
-            }
-        }
-        
-    }
     
-    private func checkOrderable(of ingredients: Ingredients) -> Bool {
+    private func checkOrderable(of ingredients: [Fruits: Int]) -> Bool {
         for ingredient in ingredients {
             let eachStock = fruitStore.countStock(of: ingredient.key)
             guard eachStock >= ingredient.value else { return false }
@@ -71,7 +19,7 @@ struct JuiceMaker {
     }
     
     private func startBlending(of juice: Juice) {
-        juice.receipe.forEach {
+        juice.recipe.forEach {
             fruitStore.decrease(of: $0.key, amount: $0.value)
         }
     }


### PR DESCRIPTION
안녕하세요 콘🌟  @protocorn93
이번에 쥬스메이커 프로젝트를 같이 진행하게 된 Avery와 Jenna입니다!
미숙한 부분이 많은 코드지만 읽어보시고 피드백 주시면 열심히 공부해서 반영해보겠습니다🔥
새해 복 많이 받으세요!!!
　 
　 
# 🧃 구현사항
### Fruits
- 재료가 되는 과일의 종류에 대한 열거형
- CaseIterable프로토콜 채택으로 타입변수 allCases를 생성
- [x] 사용할 과일 5종을 정의

### Juice
- 과일로 만드는 쥬스의 종류에 대한 열거형
- 재료조합명을 String원시값으로 가짐
- case별로 필요한 재료의 수량을 딕셔너리로 저장(`recipe`)
- [x] 과일로 제조할 쥬스 7종을 정의
- [x] 각 쥬스 제조에 필요한 정해진 개수의 과일 목록을 제시

### FruitStore
- 과일의 재고를 관리하는 클래스
- 생성 시, 딕셔너리 `stocks`에 `Fruits`의 `allCases`요소들을 key로, 기본값(10)을 value로 갖는 재고 쌍을 저장
- 싱글턴 패턴 적용: 통일된 단 하나의 창고객체가 필요하므로 과일저장소를 싱글턴 클래스로 구현
- [x] 과일별 재고를 저장
   - [x] 초기값: 각 10개
- [x] 과일별 재고를 확인
- [x] 과일별 재고를 변경

### JuiceMaker
- 주문이 들어온 쥬스를 만들 수 있는지 확인하고 제조하는 구조체
- FruitStore의 유일한 인스턴스(`fruitStore`)를 소유
- 현재 단계에서는 외부에서 호출될 일이 없는 속성과 메서드를 `private`으로 선언
- [x] 주문이 들어온 쥬스의 제조가 가능한지 판별
- [x] 주문이 들어온 쥬스의 레시피에 따라 과일별 재고를 소모


　 
　 
　 
# 🧃 고민했던 부분
## ✔  M-V-C사이의 로직 분배
패턴에서 로직에 관한 코드는 Model, Controller 중 어디로 가야 하는지 고민했습니다. 
`FruitStore`의 `countStock(of:)`와 같이 단순히 내부에 저장된 값을 확인해 주는 코드는 모델에 있기에 적합하지만, 
`JuiceMaker`의 `startBlending()`은 `FruitStore`의 `decrease()`를 불러오는데,  이는 유저의 쥬스 제조 버튼을  누름을 뷰컨트롤러에서 받아오면 모델의 값을 변경하는 부분으로 모델보다 컨트롤러(ViewController)에서 관리하는 편이 좋지 않을까 라고 생각했습니다. 
MVC 패턴의 포인트는 View와 Model의 분리라고 알고 있는데, 컨트롤러에는 어느정도의 역할이 할당되면 좋을지 궁금합니다.

　
## ✔  주문 가능 여부
1. `특정 재료의 재고가 충분한가`
2. `메뉴가 주문 가능한가`(= 모든 재료의 재고가 충분한가)

처음엔 위와 같은 Bool타입 변수 2개를 따로 만들 생각이었습니다. 
이후 재고 및 메뉴상태 관리 기능에 필요할 것 같아서였으나, 고민 끝에 다음과 같은 이유로 `2번`만 구현했습니다. (`checkOrderable(of:)`)
> 현재 단계로서는 '입력받은 메뉴의 레시피가 결국 제조 가능한가' 여부를 구하는 것까지가 요구사항인 점, 
> 따라서 '어떤 재료가 부족한가'는 중요하지 않다는 점, 
> 어떤 재료가 부족하든(~~`1번`~~), 하나라도 부족한 게 발견된 순간 `2번`을 false로 반환하고 조기종료하고자 for-in문 사용(~~forEach함수~~)

　
## ✔  재고확인 시점
`startBlending(of:)`함수 내부에서 `checkOrderable(of:)`함수를 호출하기　→　호출하지 않기
위의 MVC 로직분배에 관해 의논하는 과정에서 위와 같이 재고확인 시점을 변경했습니다. 
ViewController에서 재고확인→재고소진(음료제조) 순서대로 각자 호출하는 편이 적절하다고 판단했기 때문입니다. 
1. 주문을 받는다(VC구현 아직)
2. 제조 가능한 메뉴인지 확인한다
3. 제조한다

위 과정 중 3에서 2를 호출해서 동작여부를 결정하는 것이 자연어 기준으로는 순서가 맞아 보이지만, 로직적으로는 올바르지 않다는 것을 깨달았습니다. 
VC를 아직 구현하지 않은 상태지만, VC에서 '2를 먼저 검증 후 3을 아예 실행하지 않거나 실행하도록' 하는 편이 적절한 코드이고,
3 시점에 '제조하거나 하지 않는다'로 에러·얼럿을 띄우는 분기처리를 할 예정인데 내부호출로 구현하면 이 부분이 깔끔하지 못할 거라 생각했습니다.
(+ 두 함수의 매개변수 타입은 기존의 내부호출을 염두에 두고 설정한 것으로, 이후 수정될 수 있습니다)

　
## ✔  구현을 보류한 것들
- [ ] **재고 감소 메서드만 구현**
   재고 변경 방법이 다양할 듯하여 재고변경을 감소&증가 2가지로 분리하였으며, 
   현재로선 과일재고를 사용하기만 하므로 재고 증가 메서드는 구현하지 않았습니다. 
   이후 스텝 요구조건에 따라 차근차근 구현해보겠습니다! 
- [ ] **에러처리**
   재고나 주문에 관한 에러 구현도 이후 스텝 진행하며 더 고민해보겠습니다..!
- [ ] **옵저버**
   과일 재고의 변동을 수시로 확인하고 업데이트 하기 위해 옵저빙 방법을 같이 공부해보기로 했습니다.
   현업에서 많이 쓰거나 저희 프로젝트 성격을 고려할 때 추천하실 만한 옵저빙 방법이 있다면 조언 부탁드립니다!
- [ ] **기타**
   이외에도 레시피들의 재료 수가 일정하다면 재고확인이나 재고소진 코드의 효율성을 위해 forEach를 어떤 매칭패턴으로 대체할 수 있을까, 메뉴의 주문 가능 여부를 메뉴별 변수나 연관값으로 만들까 등등 많은 고민을 했지만 여러모로 다음 스텝을 진행해봐야 알겠다는 결론을 내렸습니다. 

　
　