### PR TITLE
JuiceMaker [STEP 1] Logan, Blue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+**/.DS_Store

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -15,6 +15,11 @@
 		C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3F255D0CDE00020D38 /* Assets.xcassets */; };
 		C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
 		C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */; };
+		F0FDFED22963F38600AD4DB7 /* Fruits.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0FDFED12963F38600AD4DB7 /* Fruits.swift */; };
+		F13008F82963B79A00E7467F /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13008F72963B79A00E7467F /* Fruit.swift */; };
+		F13008FB2963E3A500E7467F /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13008FA2963E3A500E7467F /* Errors.swift */; };
+		F18963FA29651D2100B3A9CF /* OrderMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18963F929651D2100B3A9CF /* OrderMessage.swift */; };
+		F1B39502296403F500800CE4 /* RecipeMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B39501296403F500800CE4 /* RecipeMessage.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +33,11 @@
 		C73DAF42255D0CDF00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C73DAF44255D0CDF00020D38 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMaker.swift; sourceTree = "<group>"; };
+		F0FDFED12963F38600AD4DB7 /* Fruits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruits.swift; sourceTree = "<group>"; };
+		F13008F72963B79A00E7467F /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
+		F13008FA2963E3A500E7467F /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
+		F18963F929651D2100B3A9CF /* OrderMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderMessage.swift; sourceTree = "<group>"; };
+		F1B39501296403F500800CE4 /* RecipeMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeMessage.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -54,6 +64,8 @@
 		C71CD66F266C7B500038B9CB /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				F13008F72963B79A00E7467F /* Fruit.swift */,
+				F18963F929651D2100B3A9CF /* OrderMessage.swift */,
 				C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */,
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
 			);
@@ -89,12 +101,23 @@
 		C73DAF35255D0CDD00020D38 /* JuiceMaker */ = {
 			isa = PBXGroup;
 			children = (
+				F13008F92963E39300E7467F /* Enum */,
 				C71CD66D266C7B470038B9CB /* Controller */,
 				C71CD66F266C7B500038B9CB /* Model */,
 				C71CD671266C7B570038B9CB /* View */,
 				C73DAF44255D0CDF00020D38 /* Info.plist */,
 			);
 			path = JuiceMaker;
+			sourceTree = "<group>";
+		};
+		F13008F92963E39300E7467F /* Enum */ = {
+			isa = PBXGroup;
+			children = (
+				F13008FA2963E3A500E7467F /* Errors.swift */,
+				F0FDFED12963F38600AD4DB7 /* Fruits.swift */,
+				F1B39501296403F500800CE4 /* RecipeMessage.swift */,
+			);
+			path = Enum;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -167,11 +190,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F0FDFED22963F38600AD4DB7 /* Fruits.swift in Sources */,
+				F13008F82963B79A00E7467F /* Fruit.swift in Sources */,
+				F18963FA29651D2100B3A9CF /* OrderMessage.swift in Sources */,
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
 				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
+				F1B39502296403F500800CE4 /* RecipeMessage.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,
+				F13008FB2963E3A500E7467F /* Errors.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JuiceMaker/JuiceMaker/Enum/Errors.swift
+++ b/JuiceMaker/JuiceMaker/Enum/Errors.swift
@@ -1,0 +1,25 @@
+//
+//  Errors.swift
+//  JuiceMaker
+//
+//  Created by DONGWOOK SEO on 2023/01/03.
+//
+
+import Foundation
+
+enum Errors: LocalizedError {
+    case ouOfStock
+    case notEnuoghCoin
+    case outOfExchanges
+    
+    var errorDescription: String? {
+        switch self {
+        case .ouOfStock:
+            return "재고없음"
+        case .notEnuoghCoin:
+            return "잔액부족"
+        case .outOfExchanges:
+            return "거스름돈 부족"
+        }
+    }
+}

--- a/JuiceMaker/JuiceMaker/Enum/Fruits.swift
+++ b/JuiceMaker/JuiceMaker/Enum/Fruits.swift
@@ -1,0 +1,24 @@
+//
+//  Fruits.swift
+//  JuiceMaker
+//
+//  Created by 김보미 on 2023/01/03.
+//
+
+import Foundation
+
+enum Fruits: String, CaseIterable {
+    case strawberry = "Sb"
+    case banana = "Bn"
+    case kiwi = "Kw"
+    case pineapple = "Pa"
+    case mango = "Mg"
+    
+    static func makeFruitArray() -> [String:Fruit] {
+        var initializedFruitArray = [String:Fruit]()
+        Fruits.allCases.forEach {
+            initializedFruitArray[$0.rawValue] = Fruit(name: $0.rawValue, stock: 10)
+        }
+        return initializedFruitArray
+    }
+}

--- a/JuiceMaker/JuiceMaker/Enum/RecipeMessage.swift
+++ b/JuiceMaker/JuiceMaker/Enum/RecipeMessage.swift
@@ -1,0 +1,32 @@
+//
+//  RecipeMessage.swift
+//  JuiceMaker
+//
+//  Created by DONGWOOK SEO on 2023/01/03.
+//
+
+import Foundation
+
+enum RecipeMessage: String {
+    case strawberryJuice = "Sb16"
+    case bananaJuice = "Bn2"
+    case kiwiJuice = "Kw3"
+    case pineappleJuice = "Pa2"
+    case strawBananaJuice = "Sb10+Bn1"
+    case mangoJuice = "Mg3"
+    case mangoKiwiJuice = "Mg2+Kw1"
+    
+    static func translate(recipeMessage :String) -> [OrderMessage] {
+        var convertedString: [OrderMessage] = []
+        
+        let splitedString = recipeMessage.split(separator: "+")
+        splitedString.forEach{
+            let fruitCode = String($0.prefix(2))
+            let amountStartIndex = $0.index($0.startIndex, offsetBy: 2)
+            let amountCode = Int($0[amountStartIndex...]) ?? 0
+            
+            convertedString.append(OrderMessage(fruitName: fruitCode, amount: amountCode))
+        }
+        return convertedString
+    }
+}

--- a/JuiceMaker/JuiceMaker/Model/Fruit.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruit.swift
@@ -1,0 +1,13 @@
+//
+//  Fruit.swift
+//  JuiceMaker
+//
+//  Created by DONGWOOK SEO on 2023/01/03.
+//
+
+import Foundation
+
+struct Fruit {
+    let name: String
+    var stock: Int
+}

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -8,5 +8,35 @@ import Foundation
 
 // 과일 저장소 타입
 class FruitStore {
+    static let shared = FruitStore()
     
+    var fruits: [String:Fruit] = Fruits.makeFruitArray()
+    
+    func increaseStock(of fruit: String, by amount: Int = 1) {
+        guard fruits.keys.contains(fruit) else { return }
+        
+        fruits[fruit]?.stock += amount
+    }
+    
+    func decreaseStock(of fruit: String, by amount: Int = 1) {
+        guard fruits.keys.contains(fruit) else { return }
+        guard fruits[fruit]?.stock ?? 0 > 0 else { return }
+        
+        fruits[fruit]?.stock -= amount
+    }
+    
+    func changeStock(of fruit: String, by amount: Int) {
+        if amount.signum() == 1 {
+            increaseStock(of: fruit, by: amount)
+            return
+        } else if amount.signum() == -1 {
+            decreaseStock(of: fruit, by: amount)
+            return
+        } else {
+            print("Error")
+            return
+        }
+    }
+    
+    private init() {}
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -8,5 +8,9 @@ import Foundation
 
 // 쥬스 메이커 타입
 struct JuiceMaker {
-    
+    func makeJuice(by message: [OrderMessage]) {
+        message.forEach {
+            FruitStore.shared.changeStock(of: $0.fruitName, by: $0.amount)
+        }
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/OrderMessage.swift
+++ b/JuiceMaker/JuiceMaker/Model/OrderMessage.swift
@@ -1,0 +1,13 @@
+//
+//  OrderMessage.swift
+//  JuiceMaker
+//
+//  Created by DONGWOOK SEO on 2023/01/04.
+//
+
+import Foundation
+
+struct OrderMessage {
+    let fruitName : String
+    let amount: Int
+}


### PR DESCRIPTION

>안녕하세요, 웨더! (@sungpyo)
쥬스메이커 프로젝트를 진행하게 된 **Team Bu-Lo**의 Blue & Logan입니다! ✋
코드 작성 전 생각하고 코딩하기 위해 노력하고, 많이 얘기 나누어 보았습니다.
아직 많이 어설프겠지만 피드백 주신 내용 열심히 고민하고 학습하여 반영하겠습니다 😆
리뷰 감사드립니다!💙 새해 복 많이 받으세요! 🥰


---
## ✅ 요구사항 분석 및 구현사항

**Step 1 쥬스 메이커 타입 정의**

- [x]  FruitStore 타입 정의
    - [x]  관리하는 과일: 딸기, 바나나, 파인애플, 키위, 망고
    - [x]  과일의 초기 재고: 10개
    - [x]  과일 수량변경 기능
- [x]  JuiceMaker 타입 정의
    - [x]  레시피에 맞춰 과일주스 제조
    - [x]  과일의 재고가 부족하면 쥬스 제조 불가
    - [x]  FruitStore를 소유하고 있음

## 🗝️ 학습 키워드

- string.index
- enum - rawValue의 사용
- Singleton
- protocol 의존성 주입 **(학습 필요)**

## ☄️ 고민과 해결

1. **`FruitStore`는 왜 class로 구현되어 있었을까?**    
    과제를 처음 받았을 때 `class FruitStore {}` 형태로 구현이 되어있는 것을 보고 **singleton**으로    
    구현할 것을 의도한 것이 아닌가! 하여 구현해 보려고 하였습니다.    
    `FruitStore`를 singleton으로 사용하고자 한 이유는 아래와 같습니다.
    - 과일 재고 저장소이기 때문에 과일쥬스를 만들 때 과일을 가져다 써야 함
    - 과일의 재고를 추가하거나 감소시키는 기능이 있어야 함
    - 위의 기능을 수행할 때 `FruitStore`가 아닌 **외부에서 접근할 가능성**이 있고, 한 곳에서 재고가    
        관리되어야 하므로, `singleton`으로 구현할 필요성 느낌
    
2. **쥬스를 주문하는 경우 어떠한 형식으로 전달받을 것인가?**    
    쥬스 버튼을 눌렀을 때 어떤 쥬스인지, 쥬스를 만들 때 어떤 재료가 얼마나 들어가는지에 대해 고민해    
    보았습니다. `String` 타입으로 메세징을 한다고 가정한 후 아래와 같은 규칙을 정립하고 구현해 보았습니다.
    - 메세지의 규칙을 정하여 쥬스별 레시피 String 제작
        - 과일 재료 요약어와 필요한 재료 수를 붙임
        - 2가지 이상의 재료가 필요한 경우 `+`로 연결
        - `예) 딸기쥬스 - Sb16, 딸바쥬스 - Sb10+Bn1`
    - 쥬스 버튼을 누르면 전달될 메세지를 `enum`으로 정의
    - 버튼을 누르면 해당 쥬스에 맞는 메세지가 `makeJuice`로 전달 (미구현!)
        (Step 1 요구사항에는 명시되어있지 않아서 미구현 상태입니다!)
        
    **JuiceMaker.swift**
    ```swift
    enum RecipeMessage: String {
        case strawberryJuice = "Sb16"
        case bananaJuice = "Bn2"
        case kiwiJuice = "Kw3"
        case pineappleJuice = "Pa2"
        case strawBananaJuice = "Sb10+Bn1"
        case mangoJuice = "Mg3"
        case mangoKiwiJuice = "Mg2+Kw1"
    ```
    
3. **`JuiceMaker` 에게 쥬스제작에 필요한 재료들과 그 양을 어떻게 전달할 것인가?**    
    - 각 쥬스종류를 `Enum`으로 정의한후 필요한 과일 이름과 갯수를 특정 코드와 숫자로하여 원시값으로    
        String으로 정의하고 전달할 수 있게 함.
        - 이후 버튼이 눌릴때마다 원시값(`RecipeMessage`의 Rawvalue)는 해당 `Enum`의 타입메서드인 `translate`에 의해서 `String`에서 구조체인 `OrderMessage`로 변환되어 반환된다.

    **JuiceMaker.swift**
    ```swift
    enum RecipeMessage: String {
        // ...

        static func translate(recipeMessage :String) -> [OrderMessage] {
            var convertedString: [OrderMessage] = []

            let splitedString = recipeMessage.split(separator: "+")
            splitedString.forEach{
                let fruitCode = String($0.prefix(2))
                let amountStartIndex = $0.index($0.startIndex, offsetBy: 2)
                let amountCode = Int($0[amountStartIndex...]) ?? 0

                convertedString.append(OrderMessage(fruitName: fruitCode, amount: amountCode))
            }
            return convertedString
        }
    }
    ```


4. **`JuiceMaker`는 왜 struct로 구현되어 있는가?**    
        아래의 구조체 사용 case 중 **다른 타입으로부터 상속받거나 자신을 상속할 필요가 없을 때**에 해당한다고    
        생각하여 struct로 구현되어 있는 것이라고 생각하였습니다.
    - 애플은 [가이드라인](https://developer.apple.com/documentation/swift/choosing-between-structures-and-classes)에서 다음 조건 중 하나 이상에 해당한다면 구조체를 사용할 것을 권장함
        - 연관된 간단한 값의 집합을 캡슐화하는 것만이 목적일 때
        - 캡슐화한 값을 참조하는 것보다 복사하는 것이 합당할 때
        - 구조체에 저장된 프로퍼티가 값 타입이며 참조하는 것보다 복사하는 것이 합당할 때
        - 다른 타입으로부터 상속받거나 자신을 상속할 필요가 없을 때


---
## 🙋 질문

1. 저희가 구현한 레씨피(`RecipeMessage`의 rawValue)를 전달하는 방식이 바람직한지 의문이 듭니다.
    - **의도**: 각 switch로 메뉴별로 분기를 나눠서 할수도 있었지만 추후에 과일들이 들어가는 양과 조합이 달라질 수 있다는걸 고려해서 조금더 유연한 설계를 목적으로 했습니다.
    - 조금더 효율적이고 좋은 방법이 있으시다면 힌트를 주시면 감사하겠습니다!
2. 주말동안 개인적으로 protocol, 의존성 주입에 대해 학습 후 이번 프로젝트에 적용해 볼 예정입니다!    
    혹시 웨더가 생각하기에 protocol을 사용해 봤으면 좋겠다! 싶은 부분이 있다면 힌트 좀 주실수 있을까요?    
    왜 사용해야 하는가? 에 대한 부분은 저희가 학습하면서 찾아보고, 다음 PR에서 질문드리도록 하겠습니다!