### PR TITLE
쥬스메이커 [STEP 3] Toughie, d.o

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -9,12 +9,12 @@
 /* Begin PBXBuildFile section */
 		8608A23E2966BAA300E8296A /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8608A23D2966BAA300E8296A /* Fruit.swift */; };
 		8608A2402966BCBF00E8296A /* InfoMessageError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8608A23F2966BCBF00E8296A /* InfoMessageError.swift */; };
+		865B1D7C29713AD000B4C3E5 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3C255D0CDD00020D38 /* Main.storyboard */; };
 		86C4D879296FD0A600D07F13 /* StringConstatns.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86C4D836296E9BA700D07F13 /* StringConstatns.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
 		C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* ViewController.swift */; };
-		C73DAF3E255D0CDD00020D38 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3C255D0CDD00020D38 /* Main.storyboard */; };
 		C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3F255D0CDE00020D38 /* Assets.xcassets */; };
 		C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
 		C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */; };
@@ -35,7 +35,7 @@
 		C73DAF3F255D0CDE00020D38 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C73DAF42255D0CDF00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C73DAF44255D0CDF00020D38 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMaker.swift; sourceTree = "<group>"; };
+		C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = JuiceMaker.swift; path = JuiceMaker/Model/JuiceMaker.swift; sourceTree = SOURCE_ROOT; };
 		E7F2DBAA2966BBD7000B06A0 /* FruitJuice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitJuice.swift; sourceTree = "<group>"; };
 		E7FBB6EF296C039000B412AA /* ChangeStockViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeStockViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -169,9 +169,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				865B1D7C29713AD000B4C3E5 /* Main.storyboard in Resources */,
 				C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */,
 				C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */,
-				C73DAF3E255D0CDD00020D38 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
@@ -8,25 +8,60 @@
 import UIKit
 
 class ChangeStockViewController: UIViewController {
-
+    @IBOutlet weak var strawberryLabel: UILabel!
+    @IBOutlet weak var bananaLabel: UILabel!
+    @IBOutlet weak var pineappleLabel: UILabel!
+    @IBOutlet weak var kiwiLabel: UILabel!
+    @IBOutlet weak var mangoLabel: UILabel!
+    
+    @IBOutlet weak var strawberryStepper: UIStepper!
+    @IBOutlet weak var bananaStepper: UIStepper!
+    @IBOutlet weak var pineappleStepper: UIStepper!
+    @IBOutlet weak var kiwiStepper: UIStepper!
+    @IBOutlet weak var mangoStepper: UIStepper!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        setup()
+    }
+    
+    func setup() {
+        guard let strawberry = FruitStore.shared.fruitStock[.strawberry],
+              let banana = FruitStore.shared.fruitStock[.banana],
+              let pineapple = FruitStore.shared.fruitStock[.pineapple],
+              let mango = FruitStore.shared.fruitStock[.mango],
+              let kiwi = FruitStore.shared.fruitStock[.kiwi]
+        else { return }
+        strawberryLabel.text = String(Int(strawberry))
+        bananaLabel.text = String(Int(banana))
+        pineappleLabel.text = String(Int(pineapple))
+        mangoLabel.text = String(Int(mango))
+        kiwiLabel.text = String(Int(kiwi))
+        
+        strawberryStepper.value = Double(strawberry)
+        bananaStepper.value = Double(banana)
+        pineappleStepper.value = Double(pineapple)
+        mangoStepper.value = Double(mango)
+        kiwiStepper.value = Double(kiwi)
+    }
+    
+    @IBAction func strawberryStepperTapped(_ sender: UIStepper) {
+        
+    }
+    
+    @IBAction func bananaStepperTapped(_ sender: UIStepper) {
+    }
+    
+    @IBAction func pineappleStepperTapped(_ sender: UIStepper) {
+    }
+    
+    @IBAction func kiwiStepperTapped(_ sender: UIStepper) {
+    }
+    
+    @IBAction func mangoStepperTapped(_ sender: UIStepper) {
     }
     
     @IBAction func closeButtonTapped(_ sender: UIButton) {
         self.presentingViewController?.dismiss(animated: true)
     }
-    
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
 }

--- a/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 class ChangeStockViewController: UIViewController {
+    var vcon: ViewController? = nil
+    
     @IBOutlet weak var strawberryLabel: UILabel!
     @IBOutlet weak var bananaLabel: UILabel!
     @IBOutlet weak var pineappleLabel: UILabel!
@@ -32,6 +34,7 @@ class ChangeStockViewController: UIViewController {
               let mango = FruitStore.shared.fruitStock[.mango],
               let kiwi = FruitStore.shared.fruitStock[.kiwi]
         else { return }
+        
         strawberryLabel.text = String(Int(strawberry))
         bananaLabel.text = String(Int(banana))
         pineappleLabel.text = String(Int(pineapple))
@@ -46,22 +49,43 @@ class ChangeStockViewController: UIViewController {
     }
     
     @IBAction func strawberryStepperTapped(_ sender: UIStepper) {
-        
+        strawberryLabel.text = String(Int(strawberryStepper.value))
     }
     
     @IBAction func bananaStepperTapped(_ sender: UIStepper) {
+        bananaLabel.text = String(Int(bananaStepper.value))
     }
     
     @IBAction func pineappleStepperTapped(_ sender: UIStepper) {
+        pineappleLabel.text = String(Int(pineappleStepper.value))
     }
     
     @IBAction func kiwiStepperTapped(_ sender: UIStepper) {
+        kiwiLabel.text = String(Int(kiwiStepper.value))
     }
     
     @IBAction func mangoStepperTapped(_ sender: UIStepper) {
+        mangoLabel.text = String(Int(mangoStepper.value))
     }
     
     @IBAction func closeButtonTapped(_ sender: UIButton) {
+        self.presentingViewController?.dismiss(animated: true)
+    }
+    
+    @IBAction func saveButtonTapped(_ sender: UIButton) {
+        
+        FruitStore.shared.changeQuantity(of: .strawberry, num: UInt(strawberryStepper.value))
+        FruitStore.shared.changeQuantity(of: .banana, num: UInt(bananaStepper.value))
+        FruitStore.shared.changeQuantity(of: .pineapple, num: UInt(pineappleStepper.value))
+        FruitStore.shared.changeQuantity(of: .kiwi, num: UInt(kiwiStepper.value))
+        FruitStore.shared.changeQuantity(of: .mango, num: UInt(mangoStepper.value))
+        
+        vcon?.strawberryCurrentStock.text = String(Int(strawberryStepper.value))
+        vcon?.bananaCurrentStock.text = String(Int(bananaStepper.value))
+        vcon?.pineappleCurrentStock.text = String(Int(pineappleStepper.value))
+        vcon?.kiwiCurrentStock.text = String(Int(kiwiStepper.value))
+        vcon?.mangoCurrentStock.text = String(Int(mangoStepper.value))
+        
         self.presentingViewController?.dismiss(animated: true)
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
@@ -80,11 +80,7 @@ class ChangeStockViewController: UIViewController {
         FruitStore.shared.changeQuantity(of: .kiwi, num: UInt(kiwiStepper.value))
         FruitStore.shared.changeQuantity(of: .mango, num: UInt(mangoStepper.value))
         
-        vcon?.strawberryCurrentStock.text = String(Int(strawberryStepper.value))
-        vcon?.bananaCurrentStock.text = String(Int(bananaStepper.value))
-        vcon?.pineappleCurrentStock.text = String(Int(pineappleStepper.value))
-        vcon?.kiwiCurrentStock.text = String(Int(kiwiStepper.value))
-        vcon?.mangoCurrentStock.text = String(Int(mangoStepper.value))
+        vcon?.refreshLabels()
         
         self.presentingViewController?.dismiss(animated: true)
     }

--- a/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
@@ -15,7 +15,10 @@ class ChangeStockViewController: UIViewController {
         // Do any additional setup after loading the view.
     }
     
-
+    @IBAction func closeButtonTapped(_ sender: UIButton) {
+        self.presentingViewController?.dismiss(animated: true)
+    }
+    
     /*
     // MARK: - Navigation
 

--- a/JuiceMaker/JuiceMaker/Controller/StringConstatns.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StringConstatns.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 enum StringConstatns {
-    static let changeStockViewController = "ChangeStockViewController"
     static let yes = "예"
     static let no = "아니오"
     static let failAlertTitle = "제조 불가"

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -152,9 +152,10 @@ class ViewController: UIViewController {
     }
         
     func moveToChangeStockView() {
-        guard let viewController = self.storyboard?.instantiateViewController(identifier:
-                                                                                String(describing: ChangeStockViewController.self)) else { return }
-        self.navigationController?.pushViewController(viewController, animated: true)
+        let changeStockViewController = String(describing: ChangeStockViewController.self)
+        guard let viewController = self.storyboard?.instantiateViewController(identifier: changeStockViewController) else { return }
+
+        self.present(viewController, animated: true)
     }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -152,8 +152,7 @@ class ViewController: UIViewController {
     }
     
     func moveToChangeStockView() {
-<<<<<<< Updated upstream
-        if let nextVC = self.storyboard?/instantiateViewController(withIdentifier: String(describing: ChangeStockViewController.self)) as? ChangeStockViewController {
+        if let nextVC = self.storyboard?.instantiateViewController(withIdentifier: String(describing: ChangeStockViewController.self)) as? ChangeStockViewController {
             
             nextVC.strawberryLabel = self.strawberryCurrentStock
             nextVC.bananaLabel = self.bananaCurrentStock
@@ -161,20 +160,8 @@ class ViewController: UIViewController {
             nextVC.mangoLabel = self.mangoCurrentStock
             nextVC.kiwiLabel = self.kiwiCurrentStock
             
-            nextVC.vCon = self
+            nextVC.vcon = self
             self.present(nextVC, animated: true)
         }
-=======
-        let changeStockViewController = String(describing: ChangeStockViewController.self)
-        guard let changeStockVC = self.storyboard?.instantiateViewController(identifier: changeStockViewController) as? ChangeStockViewController else { return }
-        
-//        changeStockVC.strawberryLabel = self.strawberryCurrentStock
-//        changeStockVC.bananaLabel = self.bananaCurrentStock
-//        changeStockVC.pineappleLabel = self.pineappleCurrentStock
-//        changeStockVC.kiwiLabel = self.kiwiCurrentStock
-//        changeStockVC.mangoLabel = self.mangoCurrentStock
-        
-        self.present(changeStockVC, animated: true)
->>>>>>> Stashed changes
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -99,8 +99,6 @@ class ViewController: UIViewController {
         changeFruitLabels()
     }
     
-    
-    
     func order(fruitJuice: FruitJuice) {
         do {
             try juiceMaker.make(juiceName: fruitJuice)
@@ -153,9 +151,10 @@ class ViewController: UIViewController {
         }
     }
         
-        func moveToChangeStockView() {
-            guard let viewController = self.storyboard?.instantiateViewController(identifier: StringConstatns.changeStockViewController) else { return }
-            self.navigationController?.pushViewController(viewController, animated: true)
-        }
+    func moveToChangeStockView() {
+        guard let viewController = self.storyboard?.instantiateViewController(identifier:
+                                                                                String(describing: ChangeStockViewController.self)) else { return }
+        self.navigationController?.pushViewController(viewController, animated: true)
     }
+}
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -153,13 +153,6 @@ class ViewController: UIViewController {
     
     func moveToChangeStockView() {
         if let nextVC = self.storyboard?.instantiateViewController(withIdentifier: String(describing: ChangeStockViewController.self)) as? ChangeStockViewController {
-            
-            nextVC.strawberryLabel = self.strawberryCurrentStock
-            nextVC.bananaLabel = self.bananaCurrentStock
-            nextVC.pineappleLabel = self.pineappleCurrentStock
-            nextVC.mangoLabel = self.mangoCurrentStock
-            nextVC.kiwiLabel = self.kiwiCurrentStock
-            
             nextVC.vcon = self
             self.present(nextVC, animated: true)
         }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -53,7 +53,7 @@ class ViewController: UIViewController {
             break
         }
     }
-
+    
     func checkCurrentStock() {
         guard let currentStrawberry = juiceMaker.fruitStore.quantity(of: .strawberry) else {
             registerFailAlert()
@@ -150,12 +150,18 @@ class ViewController: UIViewController {
             registerFailAlert.dismiss(animated: true)
         }
     }
-        
+    
     func moveToChangeStockView() {
-        let changeStockViewController = String(describing: ChangeStockViewController.self)
-        guard let viewController = self.storyboard?.instantiateViewController(identifier: changeStockViewController) else { return }
-
-        self.present(viewController, animated: true)
+        if let nextVC = self.storyboard?/instantiateViewController(withIdentifier: String(describing: ChangeStockViewController.self)) as? ChangeStockViewController {
+            
+            nextVC.strawberryLabel = self.strawberryCurrentStock
+            nextVC.bananaLabel = self.bananaCurrentStock
+            nextVC.pineappleLabel = self.pineappleCurrentStock
+            nextVC.mangoLabel = self.mangoCurrentStock
+            nextVC.kiwiLabel = self.kiwiCurrentStock
+            
+            nextVC.vCon = self
+            self.present(nextVC, animated: true)
+        }
     }
 }
-

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -152,6 +152,7 @@ class ViewController: UIViewController {
     }
     
     func moveToChangeStockView() {
+<<<<<<< Updated upstream
         if let nextVC = self.storyboard?/instantiateViewController(withIdentifier: String(describing: ChangeStockViewController.self)) as? ChangeStockViewController {
             
             nextVC.strawberryLabel = self.strawberryCurrentStock
@@ -163,5 +164,17 @@ class ViewController: UIViewController {
             nextVC.vCon = self
             self.present(nextVC, animated: true)
         }
+=======
+        let changeStockViewController = String(describing: ChangeStockViewController.self)
+        guard let changeStockVC = self.storyboard?.instantiateViewController(identifier: changeStockViewController) as? ChangeStockViewController else { return }
+        
+//        changeStockVC.strawberryLabel = self.strawberryCurrentStock
+//        changeStockVC.bananaLabel = self.bananaCurrentStock
+//        changeStockVC.pineappleLabel = self.pineappleCurrentStock
+//        changeStockVC.kiwiLabel = self.kiwiCurrentStock
+//        changeStockVC.mangoLabel = self.mangoCurrentStock
+        
+        self.present(changeStockVC, animated: true)
+>>>>>>> Stashed changes
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -1,6 +1,9 @@
 import Foundation
 
 class FruitStore {
+    static var shared = FruitStore()
+    private init() {}
+    
     private(set) var fruitStock: [Fruit: UInt] = {
         let defaultStock: UInt = 10
         
@@ -8,12 +11,15 @@ class FruitStore {
         Fruit.allCases.forEach { fruit in
             stock[fruit] = defaultStock
         }
-        
         return stock
     }()
     
     func quantity(of fruit: Fruit) -> UInt? {
         return fruitStock[fruit]
+    }
+    
+    func changeQuantity(of fruit: Fruit, num: UInt) {
+        self.fruitStock[fruit] = num
     }
     
     func addStock(for fruit: Fruit, number: UInt) {
@@ -30,7 +36,6 @@ class FruitStore {
                   "부족한 수량: \(number - currentNumber)" )
             return
         }
-        
         fruitStock.updateValue(currentNumber - number, forKey: fruit)
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 struct JuiceMaker {
-    let fruitStore = FruitStore()
+    let fruitStore = FruitStore.shared
     
     func make(juiceName: FruitJuice) throws {
         guard isEnoughFruit(of: juiceName) else {

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -13,8 +13,8 @@
         <!--맛있는 쥬스를 만들어 드려요!-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="JuiceMaker" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC" customClass="viewController" customModule="JuiceMaker">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -272,16 +272,16 @@
             </objects>
             <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
         </scene>
-        <!--재고 추가-->
+        <!--Change Stock View Controller-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
                 <viewController storyboardIdentifier="ChangeStockViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Yu1-lM-nqp" customClass="ChangeStockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc" customClass="viewcon">
+                    <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc" customClass="viewcon" customModule="JuiceMaker" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" spacing="38" translatesAutoresizingMaskIntoConstraints="NO" id="xFh-NH-LpI">
-                                <rect key="frame" x="111" y="89" width="622" height="156"/>
+                                <rect key="frame" x="111" y="117" width="622" height="156"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="C3g-i5-FkI">
                                         <rect key="frame" x="0.0" y="0.0" width="94" height="156"/>
@@ -390,41 +390,38 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aBx-yv-Z7p">
+                                <rect key="frame" x="790.33333333333337" y="47" width="53.666666666666629" height="34.333333333333343"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title="닫기"/>
+                                <buttonConfiguration key="configuration" style="plain" title="닫기"/>
+                                <connections>
+                                    <action selector="closeButtonTapped:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="EBl-iD-BW1"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CTz-AK-yok">
+                                <rect key="frame" x="395.33333333333331" y="293" width="53.666666666666686" height="34.333333333333314"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="저장"/>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="CTz-AK-yok" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="38V-XC-ciU"/>
                             <constraint firstItem="xFh-NH-LpI" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="3PO-xj-m9H"/>
-                            <constraint firstItem="xFh-NH-LpI" firstAttribute="top" secondItem="gcO-Xb-kNs" secondAttribute="top" constant="10" id="KMh-hA-cyI"/>
+                            <constraint firstItem="aBx-yv-Z7p" firstAttribute="top" secondItem="gcO-Xb-kNs" secondAttribute="top" id="D5h-tw-01e"/>
+                            <constraint firstItem="gcO-Xb-kNs" firstAttribute="trailing" secondItem="aBx-yv-Z7p" secondAttribute="trailing" id="Q8u-Rd-Qw2"/>
+                            <constraint firstItem="xFh-NH-LpI" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="XGG-qA-ju7"/>
+                            <constraint firstItem="CTz-AK-yok" firstAttribute="top" secondItem="xFh-NH-LpI" secondAttribute="bottom" constant="20" id="vYs-Ml-DUa"/>
                         </constraints>
                     </view>
                     <toolbarItems/>
-                    <navigationItem key="navigationItem" title="재고 추가" id="g4W-fY-l7r">
-                        <barButtonItem key="rightBarButtonItem" title="닫기" id="KAj-1t-EPq"/>
-                    </navigationItem>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1636.4928909952605" y="900"/>
-        </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="cAf-jL-tPK">
-            <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
-                    <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
-                        <rect key="frame" x="0.0" y="47" width="844" height="32"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <nil name="viewControllers"/>
-                    <connections>
-                        <segue destination="Yu1-lM-nqp" kind="relationship" relationship="rootViewController" id="wH1-3A-cBm"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="2s5-lS-967" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="1637" y="21"/>
         </scene>
     </scenes>
     <resources>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -415,9 +415,16 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CTz-AK-yok">
-                                <rect key="frame" x="395.33333333333331" y="293" width="53.666666666666686" height="34.333333333333314"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="저장"/>
+                                <rect key="frame" x="392" y="293" width="60" height="30"/>
+                                <color key="backgroundColor" red="0.73860501044468418" green="0.76540798611111116" blue="0.73310436155133007" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="CTz-AK-yok" secondAttribute="height" multiplier="2:1" id="fDu-CO-cuR"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title="저장">
+                                    <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
                                 <connections>
                                     <action selector="saveButtonTapped:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="ZNp-cR-gEp"/>
                                 </connections>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -301,6 +301,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                                 <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="strawberryStepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="3eT-kG-I7a"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
@@ -322,6 +325,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
                                                 <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="bananaStepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="IU0-pQ-EeL"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
@@ -343,6 +349,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
                                                 <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="pineappleStepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="Pew-W0-SrZ"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
@@ -364,6 +373,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
                                                 <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="kiwiStepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="I0w-dC-pbv"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
@@ -385,6 +397,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
                                                 <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="mangoStepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="TIF-Nx-hhz"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
@@ -418,6 +433,18 @@
                     </view>
                     <toolbarItems/>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
+                    <connections>
+                        <outlet property="bananaLabel" destination="gKu-86-RhI" id="gV3-du-wS4"/>
+                        <outlet property="bananaStepper" destination="O5s-2N-3iP" id="pLD-K7-7TQ"/>
+                        <outlet property="kiwiLabel" destination="ZDv-1m-HBY" id="gEz-nE-ZHT"/>
+                        <outlet property="kiwiStepper" destination="klA-59-Nu4" id="eBM-T6-Su9"/>
+                        <outlet property="mangoLabel" destination="YJI-ER-LJR" id="Doj-TO-Xg1"/>
+                        <outlet property="mangoStepper" destination="xbn-6P-grO" id="eU9-Y3-jTC"/>
+                        <outlet property="pineappleLabel" destination="MpT-VW-hCb" id="5gi-4r-So8"/>
+                        <outlet property="pineappleStepper" destination="Rcr-xr-eqz" id="1IP-Om-btF"/>
+                        <outlet property="strawberryLabel" destination="0yV-kn-zaT" id="c6i-dE-h32"/>
+                        <outlet property="strawberryStepper" destination="ZQk-f4-zrz" id="wAG-mH-XD9"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -418,6 +418,9 @@
                                 <rect key="frame" x="395.33333333333331" y="293" width="53.666666666666686" height="34.333333333333314"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="저장"/>
+                                <connections>
+                                    <action selector="saveButtonTapped:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="ZNp-cR-gEp"/>
+                                </connections>
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -14,7 +14,7 @@
         <scene sceneID="tne-QT-ifu">
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="JuiceMaker" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC" customClass="viewController" customModule="JuiceMaker" customModuleProvider="target">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC" customClass="viewcon" customModule="JuiceMaker">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -276,7 +276,7 @@
         <scene sceneID="fkG-vv-hpE">
             <objects>
                 <viewController storyboardIdentifier="ChangeStockViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Yu1-lM-nqp" customClass="ChangeStockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc" customClass="viewcon" customModule="JuiceMaker" customModuleProvider="target">
+                    <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc" customClass="viewcon" customModule="JuiceMaker">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -14,7 +14,7 @@
         <scene sceneID="tne-QT-ifu">
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="JuiceMaker" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC" customClass="viewController" customModule="JuiceMaker">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC" customClass="viewController" customModule="JuiceMaker" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>


### PR DESCRIPTION
드디어 금요일이에요 븨븨! (@YebinKim) 🙋🏻‍♂️
터피, 디오입니다!

Step3, 마지막 PR이에요~ (늦어서 죄송합니다..🥲)
어떻게 구현 했는지에 대한 설명을 간략하게 정리해 보았습니다.

항상 꼼꼼하게, 친절하게 코드 살펴보고 많은 팁들 주셔서 정말 감사해요. 
덕분에 많이 배웠고, 배우고 있어요 ! 🙆🏻‍♂️

## STEP 3

## 1. 화면 이동

- 프로퍼티를 통해 데이터를 서로 주고 받는 형태
    - 상수 nextVC에는  화면 2 ViewController가 들어있음.
    - nextVC.vcon에는 화면 1 ViewController가 들어있음.
```swift
func moveToChangeStockView() {
        if let nextVC = self.storyboard?.instantiateViewController(withIdentifier: String(describing: ChangeStockViewController.self)) as? ChangeStockViewController {
            
            nextVC.vcon = self
            self.present(nextVC, animated: true)
        }
    }
```

## 2. 재고 변경

- [ 화면 1 ] 과 [ 화면 2 ] 가 사용하는 데이터가 같으므로 싱글턴 패턴을 사용.
    
    + 레이블 리프레시의 편의성을 위해
```swift
class FruitStore {
    static var shared = FruitStore()
    private init() {}
    
    private(set) var fruitStock: [Fruit: UInt] = {
        let defaultStock: UInt = 10
        
        var stock: [Fruit: UInt] = [:]
        Fruit.allCases.forEach { fruit in
            stock[fruit] = defaultStock
        }
        return stock
    }()

	...
}
```

## 3. [ 화면 2 ] 종료 후 [ 화면 1 ] 의 Label 변경

- [ 화면 1 ] → [ 화면 2 ] 전환시
    - 화면 1 ViewController 를 화면 2 저장속성에 전달
```swift
func moveToChangeStockView() {
        if let nextVC = self.storyboard?.instantiateViewController(withIdentifier: String(describing: ChangeStockViewController.self)) as? ChangeStockViewController {
            
            nextVC.vcon = self
            self.present(nextVC, animated: true)
        }
    }
```
- [ 화면 2 ] 종료시
    - 싱글턴 객체(FruitStore)의 과일 수량 데이터(fruitStock) 변경
    - [ 화면 1 ]의 Label 변경
```swift
@IBAction func saveButtonTapped(_ sender: UIButton) {
        
				// 싱글턴 객체에 과일 수량 데이터 변경
        FruitStore.shared.changeQuantity(of: .strawberry, num: UInt(strawberryStepper.value))
        FruitStore.shared.changeQuantity(of: .banana, num: UInt(bananaStepper.value))
        FruitStore.shared.changeQuantity(of: .pineapple, num: UInt(pineappleStepper.value))
        FruitStore.shared.changeQuantity(of: .kiwi, num: UInt(kiwiStepper.value))
        FruitStore.shared.changeQuantity(of: .mango, num: UInt(mangoStepper.value))
        
				// 화면 1 의 Label 변경
        vcon?.refreshLabels()
        
        self.presentingViewController?.dismiss(animated: true)
    }
```
## 4. 저장버튼 추가 구현

- 데이터 저장, dismiss 두 가지 역할을 하는 버튼이 ‘닫기’ 로만 표기되어 있어 직관성이 떨어진다고 판단.
    - 닫으면 자동으로 저장이 되는 건지 아닌지 모호해 유저에게 불편함을 야기할 가능성 존재
    - 스테퍼를 통해 데이터를 수정하다 취소하고 싶을 때, 스테퍼를 다시 조정하는 대신 닫기를 눌러버리면 이전 행위들을 모두 취소 가능함.
- **저장 Button** → 데이터를 저장하고 dismiss까지 함(정확히 말하자면 저장 후 닫기)
- **닫기 Button** → 데이터를 저장하지 않고, dismiss만 함 (말 그대로 닫기)



### 콘솔창 에러에 관한 질문 🤔

![image](https://user-images.githubusercontent.com/99641242/212272845-d95e2dfc-2fc1-4a2b-a0a4-fe97d46d987c.png)


위와 같은 에러가 콘솔창에 찍혀 구글링을 해보았으나 해결하지 못했어요..

- Main.storyboard의 Identity inspector의 Module이 .none으로 되어 있는 경우 발생할 수 있는 에러라고 하기에 확인해 보았더니 모듈 전부 JuiceMaker로 설정되어 있어요 😧

빌드, 실행에는 문제가 없는 것처럼 보이지만 콘솔창에 계속 찍히길래 이것이 무엇인지 궁금합니다!



### 열정적으로 코드리뷰 해주셔서 다시 한 번 감사드려요!! 🙇🏻‍♂️