### PR TITLE
쥬스메이커 [Step1] 뉴준성, 쫑

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,40 @@
+# Created by https://www.toptal.com/developers/gitignore/api/macos,xcode,swift
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,xcode,swift
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Swift ###
 # Xcode
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
@@ -35,13 +72,11 @@ timeline.xctimeline
 playground.xcworkspace
 
 # Swift Package Manager
-#
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
 # Package.pins
 # Package.resolved
 # *.xcodeproj
-#
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
 # hence it is not needed unless you have added a package configuration file to your project
 # .swiftpm
@@ -49,18 +84,14 @@ playground.xcworkspace
 .build/
 
 # CocoaPods
-#
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
-#
 # Pods/
-#
 # Add this line if you want to avoid checking in source code from the Xcode workspace
 # *.xcworkspace
 
 # Carthage
-#
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
 # Carthage/Checkouts
 
@@ -71,7 +102,6 @@ Dependencies/
 .accio/
 
 # fastlane
-#
 # It is recommended to not store the screenshots in the git repo.
 # Instead, use fastlane to re-generate the screenshots whenever they are needed.
 # For more information about the recommended setup visit:
@@ -83,8 +113,22 @@ fastlane/screenshots/**/*.png
 fastlane/test_output
 
 # Code Injection
-#
 # After new code Injection tools there's a generated folder /iOSInjectionProject
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+### Xcode ###
+
+## Xcode 8 and earlier
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcodeproj/project.xcworkspace/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+**/xcshareddata/WorkspaceSettings.xcsettings
+
+# End of https://www.toptal.com/developers/gitignore/api/macos,xcode,swift

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0DC9C0152AAEABC700EC2897 /* FruitType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DC9C0142AAEABC700EC2897 /* FruitType.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
@@ -18,6 +19,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0DC9C0142AAEABC700EC2897 /* FruitType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitType.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -56,6 +58,7 @@
 			children = (
 				C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */,
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
+				0DC9C0142AAEABC700EC2897 /* FruitType.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -171,6 +174,7 @@
 				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
+				0DC9C0152AAEABC700EC2897 /* FruitType.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0DC9C0152AAEABC700EC2897 /* FruitType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DC9C0142AAEABC700EC2897 /* FruitType.swift */; };
+		A698925D2AAEB4B8005110B0 /* JuiceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A698925C2AAEB4B8005110B0 /* JuiceType.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
@@ -20,6 +21,7 @@
 
 /* Begin PBXFileReference section */
 		0DC9C0142AAEABC700EC2897 /* FruitType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitType.swift; sourceTree = "<group>"; };
+		A698925C2AAEB4B8005110B0 /* JuiceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceType.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -56,6 +58,7 @@
 		C71CD66F266C7B500038B9CB /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				A698925C2AAEB4B8005110B0 /* JuiceType.swift */,
 				C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */,
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
 				0DC9C0142AAEABC700EC2897 /* FruitType.swift */,
@@ -174,6 +177,7 @@
 				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
+				A698925D2AAEB4B8005110B0 /* JuiceType.swift in Sources */,
 				0DC9C0152AAEABC700EC2897 /* FruitType.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,
 			);

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0DC9C0152AAEABC700EC2897 /* FruitType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DC9C0142AAEABC700EC2897 /* FruitType.swift */; };
+		0DC9C0192AAEECB000EC2897 /* JuiceMakerException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DC9C0182AAEECB000EC2897 /* JuiceMakerException.swift */; };
 		A698925D2AAEB4B8005110B0 /* JuiceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A698925C2AAEB4B8005110B0 /* JuiceType.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
@@ -21,6 +22,7 @@
 
 /* Begin PBXFileReference section */
 		0DC9C0142AAEABC700EC2897 /* FruitType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitType.swift; sourceTree = "<group>"; };
+		0DC9C0182AAEECB000EC2897 /* JuiceMakerException.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMakerException.swift; sourceTree = "<group>"; };
 		A698925C2AAEB4B8005110B0 /* JuiceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceType.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -62,6 +64,7 @@
 				C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */,
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
 				0DC9C0142AAEABC700EC2897 /* FruitType.swift */,
+				0DC9C0182AAEECB000EC2897 /* JuiceMakerException.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -176,6 +179,7 @@
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
 				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
+				0DC9C0192AAEECB000EC2897 /* JuiceMakerException.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
 				A698925D2AAEB4B8005110B0 /* JuiceType.swift in Sources */,
 				0DC9C0152AAEABC700EC2897 /* FruitType.swift in Sources */,

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -14,6 +14,5 @@ class ViewController: UIViewController {
 //        JuiceMaker().foo()
         
     }
-
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -11,8 +11,9 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
+//        JuiceMaker().foo()
+        
     }
-
 
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -10,9 +10,6 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
-//        JuiceMaker().foo()
-        
     }
 }
 

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -1,6 +1,6 @@
 //
 //  JuiceMaker - FruitStore.swift
-//  Created by yagom. 
+//  Created by yagom.
 //  Copyright © yagom academy. All rights reserved.
 //
 
@@ -8,5 +8,46 @@ import Foundation
 
 // 과일 저장소 타입
 class FruitStore {
+    private var strawberry: UInt
+    private var banana: UInt
+    private var pineapple: UInt
+    private var mango: UInt
+    private var kiwi: UInt
     
+    init(strawberry: UInt, banana: UInt, pineapple: UInt, mango: UInt, kiwi: UInt) {
+        self.strawberry = strawberry
+        self.banana = banana
+        self.pineapple = pineapple
+        self.mango = mango
+        self.kiwi = kiwi
+    }
+    
+    convenience init(count: UInt) {
+        self.init(strawberry: count, banana: count, pineapple: count, mango: count, kiwi: count)
+    }
+    
+    convenience init() {
+        self.init(count: 10)
+    }
+    
+    func update(fruits: Fruit..., as option: ((UInt, UInt) -> UInt)) {
+        for fruit in fruits {
+            update(fruit, as: option)
+        }
+    }
+    
+    func update(_ fruit: Fruit, as option: ((UInt, UInt) -> UInt)) {
+        switch fruit.fruitType {
+        case .strawberry:
+            strawberry = option(strawberry, fruit.count)
+        case .banana:
+            banana = fruit.count
+        case .pineapple:
+            pineapple = fruit.count
+        case .mango:
+            mango = fruit.count
+        case .kiwi:
+            kiwi = fruit.count
+        }
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -33,65 +33,65 @@ class FruitStore {
     }
     
     func update(fruits: [Fruit], as `operator`: ((Int, Int) -> Int)) throws {
-        let checkedFruits = try checkValidation(fruits: fruits, as: `operator`)
+        let calculatedFruits = try getCalculatedCounts(of: fruits, as: `operator`)
         
-        for fruit in checkedFruits {
-            checkedUpdate(fruit)
+        for fruit in calculatedFruits {
+            applyCount(of: fruit)
         }
     }
     
     func update(_ fruit: Fruit, as `operator`: ((Int, Int) -> Int)) throws {
         switch fruit.fruitType {
         case .strawberry:
-            strawberry = try checkValidation(fruitCount: `operator`(strawberry, fruit.count))
+            strawberry = try getCalculatedCount(of: `operator`(strawberry, fruit.count))
         case .banana:
-            banana = try checkValidation(fruitCount: `operator`(banana, fruit.count))
+            banana = try getCalculatedCount(of: `operator`(banana, fruit.count))
         case .pineapple:
-            pineapple = try checkValidation(fruitCount: `operator`(pineapple, fruit.count))
+            pineapple = try getCalculatedCount(of: `operator`(pineapple, fruit.count))
         case .mango:
-            mango = try checkValidation(fruitCount: `operator`(mango, fruit.count))
+            mango = try getCalculatedCount(of: `operator`(mango, fruit.count))
         case .kiwi:
-            kiwi = try checkValidation(fruitCount: `operator`(kiwi, fruit.count))
+            kiwi = try getCalculatedCount(of: `operator`(kiwi, fruit.count))
         }
     }
     
-    private func checkedUpdate(_ checkedFruit: Fruit) {
-        switch checkedFruit.fruitType {
+    private func applyCount(of fruit: Fruit) {
+        switch fruit.fruitType {
         case .strawberry:
-            strawberry = checkedFruit.count
+            strawberry = fruit.count
         case .banana:
-            banana = checkedFruit.count
+            banana = fruit.count
         case .pineapple:
-            pineapple = checkedFruit.count
+            pineapple = fruit.count
         case .mango:
-            mango = checkedFruit.count
+            mango = fruit.count
         case .kiwi:
-            kiwi = checkedFruit.count
+            kiwi = fruit.count
         }
     }
     
-    private func checkValidation(fruits: [Fruit], as `operator`: ((Int, Int) -> Int)) throws -> [Fruit] {
+    private func getCalculatedCounts(of fruits: [Fruit], as `operator`: ((Int, Int) -> Int)) throws -> [Fruit] {
         var checkedFruits = [Fruit]()
         for (fruitType, count) in fruits {
             var checkedCount = 0
             switch fruitType {
             case .strawberry:
-                checkedCount = try checkValidation(fruitCount: `operator`(strawberry, count))
+                checkedCount = try getCalculatedCount(of: `operator`(strawberry, count))
             case .banana:
-                checkedCount = try checkValidation(fruitCount: `operator`(banana, count))
+                checkedCount = try getCalculatedCount(of: `operator`(banana, count))
             case .pineapple:
-                checkedCount = try checkValidation(fruitCount: `operator`(pineapple, count))
+                checkedCount = try getCalculatedCount(of: `operator`(pineapple, count))
             case .mango:
-                checkedCount = try checkValidation(fruitCount: `operator`(mango, count))
+                checkedCount = try getCalculatedCount(of: `operator`(mango, count))
             case .kiwi:
-                checkedCount = try checkValidation(fruitCount: `operator`(kiwi, count))
+                checkedCount = try getCalculatedCount(of: `operator`(kiwi, count))
             }
             checkedFruits.append(Fruit(fruitType, checkedCount))
         }
         return checkedFruits
     }
     
-    private func checkValidation(fruitCount: Int) throws -> Int {
+    private func getCalculatedCount(of fruitCount: Int) throws -> Int {
         if fruitCount < 0 {
             throw JuiceMakerException.negativeCountError
         }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -8,13 +8,13 @@ import Foundation
 
 // 과일 저장소 타입
 class FruitStore {
-    private var strawberry: UInt
-    private var banana: UInt
-    private var pineapple: UInt
-    private var mango: UInt
-    private var kiwi: UInt
+    private var strawberry: Int
+    private var banana: Int
+    private var pineapple: Int
+    private var mango: Int
+    private var kiwi: Int
     
-    init(strawberry: UInt, banana: UInt, pineapple: UInt, mango: UInt, kiwi: UInt) {
+    init(strawberry: Int, banana: Int, pineapple: Int, mango: Int, kiwi: Int) {
         self.strawberry = strawberry
         self.banana = banana
         self.pineapple = pineapple
@@ -22,7 +22,7 @@ class FruitStore {
         self.kiwi = kiwi
     }
     
-    convenience init(count: UInt) {
+    convenience init(count: Int) {
         self.init(strawberry: count, banana: count, pineapple: count, mango: count, kiwi: count)
     }
     
@@ -30,25 +30,50 @@ class FruitStore {
         self.init(count: 10)
     }
     
-    func update(fruits: [Fruit], as option: ((UInt, UInt) -> UInt)) {
+    func update(fruits: [Fruit], as `operator`: ((Int, Int) -> Int)) throws {
+        try checkValidation(fruits: fruits, as: `operator`)
+        
         for fruit in fruits {
-            update(fruit, as: option)
+            try update(fruit, as: `operator`)
         }
     }
     
-    func update(_ fruit: Fruit, as option: ((UInt, UInt) -> UInt)) {
+    func update(_ fruit: Fruit, as `operator`: ((Int, Int) -> Int)) throws {
         switch fruit.fruitType {
         case .strawberry:
-            strawberry = option(strawberry, fruit.count)
-            print(strawberry)
+            strawberry = try checkValidation(fruitCount: `operator`(strawberry, fruit.count))
         case .banana:
-            banana = option(banana, fruit.count)
+            banana = try checkValidation(fruitCount: `operator`(banana, fruit.count))
         case .pineapple:
-            pineapple = option(pineapple, fruit.count)
+            pineapple = try checkValidation(fruitCount: `operator`(pineapple, fruit.count))
         case .mango:
-            mango = option(mango, fruit.count)
+            mango = try checkValidation(fruitCount: `operator`(mango, fruit.count))
         case .kiwi:
-            kiwi = option(kiwi, fruit.count)
+            kiwi = try checkValidation(fruitCount: `operator`(kiwi, fruit.count))
         }
+    }
+    
+    private func checkValidation(fruits: [Fruit], as `operator`: ((Int, Int) -> Int)) throws {
+        for fruit in fruits {
+            switch fruit.fruitType {
+            case .strawberry:
+                let _ = try checkValidation(fruitCount: `operator`(strawberry, fruit.count))
+            case .banana:
+                let _ = try checkValidation(fruitCount: `operator`(banana, fruit.count))
+            case .pineapple:
+                let _ = try checkValidation(fruitCount: `operator`(pineapple, fruit.count))
+            case .mango:
+                let _ = try checkValidation(fruitCount: `operator`(mango, fruit.count))
+            case .kiwi:
+                let _ = try checkValidation(fruitCount: `operator`(kiwi, fruit.count))
+            }
+        }
+    }
+    
+    private func checkValidation(fruitCount: Int) throws -> Int {
+        if fruitCount < 0 {
+            throw JuiceMakerException.negativeCountError
+        }
+        return fruitCount
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -31,10 +31,10 @@ class FruitStore {
     }
     
     func update(fruits: [Fruit], as `operator`: ((Int, Int) -> Int)) throws {
-        try checkValidation(fruits: fruits, as: `operator`)
+        let checkedFruits = try checkValidation(fruits: fruits, as: `operator`)
         
-        for fruit in fruits {
-            try update(fruit, as: `operator`)
+        for fruit in checkedFruits {
+            checkedUpdate(fruit)
         }
     }
     
@@ -53,21 +53,40 @@ class FruitStore {
         }
     }
     
-    private func checkValidation(fruits: [Fruit], as `operator`: ((Int, Int) -> Int)) throws {
-        for fruit in fruits {
-            switch fruit.fruitType {
-            case .strawberry:
-                let _ = try checkValidation(fruitCount: `operator`(strawberry, fruit.count))
-            case .banana:
-                let _ = try checkValidation(fruitCount: `operator`(banana, fruit.count))
-            case .pineapple:
-                let _ = try checkValidation(fruitCount: `operator`(pineapple, fruit.count))
-            case .mango:
-                let _ = try checkValidation(fruitCount: `operator`(mango, fruit.count))
-            case .kiwi:
-                let _ = try checkValidation(fruitCount: `operator`(kiwi, fruit.count))
-            }
+    private func checkedUpdate(_ checkedFruit: Fruit) {
+        switch checkedFruit.fruitType {
+        case .strawberry:
+            strawberry = checkedFruit.count
+        case .banana:
+            banana = checkedFruit.count
+        case .pineapple:
+            pineapple = checkedFruit.count
+        case .mango:
+            mango = checkedFruit.count
+        case .kiwi:
+            kiwi = checkedFruit.count
         }
+    }
+    
+    private func checkValidation(fruits: [Fruit], as `operator`: ((Int, Int) -> Int)) throws -> [Fruit] {
+        var checkedFruits = [Fruit]()
+        for (fruitType, count) in fruits {
+            var checkedCount = 0
+            switch fruitType {
+            case .strawberry:
+                checkedCount = try checkValidation(fruitCount: `operator`(strawberry, count))
+            case .banana:
+                checkedCount = try checkValidation(fruitCount: `operator`(banana, count))
+            case .pineapple:
+                checkedCount = try checkValidation(fruitCount: `operator`(pineapple, count))
+            case .mango:
+                checkedCount = try checkValidation(fruitCount: `operator`(mango, count))
+            case .kiwi:
+                checkedCount = try checkValidation(fruitCount: `operator`(kiwi, count))
+            }
+            checkedFruits.append(Fruit(fruitType, checkedCount))
+        }
+        return checkedFruits
     }
     
     private func checkValidation(fruitCount: Int) throws -> Int {

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -30,7 +30,7 @@ class FruitStore {
         self.init(count: 10)
     }
     
-    func update(fruits: Fruit..., as option: ((UInt, UInt) -> UInt)) {
+    func update(fruits: [Fruit], as option: ((UInt, UInt) -> UInt)) {
         for fruit in fruits {
             update(fruit, as: option)
         }
@@ -40,6 +40,7 @@ class FruitStore {
         switch fruit.fruitType {
         case .strawberry:
             strawberry = option(strawberry, fruit.count)
+            print(strawberry)
         case .banana:
             banana = option(banana, fruit.count)
         case .pineapple:

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -10,11 +10,11 @@ import Foundation
 class FruitStore {
     static let shared = FruitStore()
     
-    var strawberry: Int
-    var banana: Int
-    var pineapple: Int
-    var mango: Int
-    var kiwi: Int
+    private(set) var strawberry: Int
+    private(set) var banana: Int
+    private(set) var pineapple: Int
+    private(set) var mango: Int
+    private(set) var kiwi: Int
     
     private init(strawberry: Int, banana: Int, pineapple: Int, mango: Int, kiwi: Int) {
         self.strawberry = strawberry

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -41,13 +41,13 @@ class FruitStore {
         case .strawberry:
             strawberry = option(strawberry, fruit.count)
         case .banana:
-            banana = fruit.count
+            banana = option(banana, fruit.count)
         case .pineapple:
-            pineapple = fruit.count
+            pineapple = option(pineapple, fruit.count)
         case .mango:
-            mango = fruit.count
+            mango = option(mango, fruit.count)
         case .kiwi:
-            kiwi = fruit.count
+            kiwi = option(kiwi, fruit.count)
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -8,13 +8,15 @@ import Foundation
 
 // 과일 저장소 타입
 class FruitStore {
-    private var strawberry: Int
-    private var banana: Int
-    private var pineapple: Int
-    private var mango: Int
-    private var kiwi: Int
+    static let shared = FruitStore()
     
-    init(strawberry: Int, banana: Int, pineapple: Int, mango: Int, kiwi: Int) {
+    var strawberry: Int
+    var banana: Int
+    var pineapple: Int
+    var mango: Int
+    var kiwi: Int
+    
+    private init(strawberry: Int, banana: Int, pineapple: Int, mango: Int, kiwi: Int) {
         self.strawberry = strawberry
         self.banana = banana
         self.pineapple = pineapple
@@ -22,11 +24,11 @@ class FruitStore {
         self.kiwi = kiwi
     }
     
-    convenience init(count: Int) {
+    private convenience init(count: Int) {
         self.init(strawberry: count, banana: count, pineapple: count, mango: count, kiwi: count)
     }
     
-    convenience init() {
+    private convenience init() {
         self.init(count: 10)
     }
     

--- a/JuiceMaker/JuiceMaker/Model/FruitType.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitType.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-typealias Fruit = (fruitType: FruitType, count: UInt)
+typealias Fruit = (fruitType: FruitType, count: Int)
 
 enum FruitType {
     case strawberry

--- a/JuiceMaker/JuiceMaker/Model/FruitType.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitType.swift
@@ -1,0 +1,18 @@
+//
+//  FruitType.swift
+//  JuiceMaker
+//
+//  Created by 김준성 on 2023/09/11.
+//
+
+import Foundation
+
+typealias Fruit = (fruitType: FruitType, count: UInt)
+
+enum FruitType {
+    case strawberry
+    case banana
+    case pineapple
+    case mango
+    case kiwi
+}

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -8,16 +8,15 @@ import Foundation
 
 // 쥬스 메이커 타입
 struct JuiceMaker {
-    private var fruitStore = FruitStore()
     func make(juice: JuiceType) throws {
-        try fruitStore.update(fruits: juice.ingredients, as: +)
+        try FruitStore.shared.update(fruits: juice.ingredients, as: +)
     }
 
     func add(fruit: Fruit) throws {
-        try fruitStore.update(fruit, as: +)
+        try FruitStore.shared.update(fruit, as: +)
     }
 
     func sub(fruit: Fruit) throws {
-        try fruitStore.update(fruit, as: -)
+        try FruitStore.shared.update(fruit, as: -)
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -9,7 +9,7 @@ import Foundation
 // 쥬스 메이커 타입
 struct JuiceMaker {
     func make(juice: JuiceType) throws {
-        try FruitStore.shared.update(fruits: juice.ingredients, as: +)
+        try FruitStore.shared.update(fruits: juice.ingredients, as: -)
     }
 
     func add(fruit: Fruit) throws {

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -12,4 +12,12 @@ struct JuiceMaker {
     func make(juice: JuiceType) throws {
         try fruitStore.update(fruits: juice.ingredients, as: +)
     }
+
+    func add(fruit: Fruit) throws {
+        try fruitStore.update(fruit, as: +)
+    }
+
+    func sub(fruit: Fruit) throws {
+        try fruitStore.update(fruit, as: -)
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -9,10 +9,7 @@ import Foundation
 // 쥬스 메이커 타입
 struct JuiceMaker {
     private var fruitStore = FruitStore()
-
-    func make(juice: JuiceType) {
-        fruitStore.update(fruits: juice.ingredients, as: -)
+    func make(juice: JuiceType) throws {
+        try fruitStore.update(fruits: juice.ingredients, as: +)
     }
-
-
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -1,12 +1,18 @@
 //
 //  JuiceMaker - JuiceMaker.swift
-//  Created by yagom. 
+//  Created by yagom.
 //  Copyright © yagom academy. All rights reserved.
-// 
+//
 
 import Foundation
 
 // 쥬스 메이커 타입
 struct JuiceMaker {
-    
+    private var fruitStore = FruitStore()
+
+    func make(juice: JuiceType) {
+        fruitStore.update(fruits: juice.ingredients, as: -)
+    }
+
+
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMakerException.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMakerException.swift
@@ -1,0 +1,12 @@
+//
+//  JuiceMakerException.swift
+//  JuiceMaker
+//
+//  Created by 김준성 on 2023/09/11.
+//
+
+import Foundation
+
+enum JuiceMakerException: Error {
+    case negativeCountError
+}

--- a/JuiceMaker/JuiceMaker/Model/JuiceType.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceType.swift
@@ -1,0 +1,37 @@
+//
+//  JuiceType.swift
+//  JuiceMaker
+//
+//  Created by imseonghyeon on 2023/09/11.
+//
+
+import Foundation
+
+enum JuiceType {
+    var ingredients: [Fruit] {
+        switch self {
+        case .strawberryJuice:
+            return [Fruit(.strawberry, 16)]
+        case .bananaJuice:
+            return [Fruit(.banana, 2)]
+        case .kiwiJuice:
+            return [Fruit(.kiwi, 3)]
+        case .pineappleJuice:
+            return [Fruit(.kiwi, 3)]
+        case .strawberrydBananaJuice:
+            return [Fruit(.strawberry, 10), Fruit(.banana, 1)]
+        case .mangoJuice:
+            return [Fruit(.mango, 3)]
+        case .mangoKiwiJuice:
+            return [Fruit(.mango, 2), Fruit(.kiwi, 1)]
+        }
+    }
+
+    case strawberryJuice
+    case bananaJuice
+    case kiwiJuice
+    case pineappleJuice
+    case strawberrydBananaJuice
+    case mangoJuice
+    case mangoKiwiJuice
+}


### PR DESCRIPTION
## 리뷰어
@jryoun1

## 파일구조
- JuiceMaker
  + Controller
  + Model
    - FruitStore
    - FruitType
    - JuiceMaker
    - JuiceMakerException
    - JuiceType
  + View

## 고민했던 점

### Fruit를 Tuple로 정의한 이유? (+ 9월 13일 9시 50분 추가)

```swift
// fruitType 과일의 종류를 의미하며, count는 대부분의 경우에서는 기존의 재고에서 빼야할 수량을 의미합니다.
// 그런데 특정경우 count가 기존 재고에서 업데이트할 수량을 의미할 수도 있습니다.
typealias Fruit = (fruitType: FruitType, count: Int)
```

저희가 Fruit이라는 자료형을 정의할 때,
dictionary, struct, class, tuple 중에서 어떤 것을 선택할 지, 고민을 많이 했습니다.
우선 dictionary는 FruitStore에 인스턴스를 생성하면, 새로운 과일을 추가할 때 편하다는 장점이 있지만,
각 과일의 수량을 변경할 때, 언래핑을 수행해야하는 불편함이 있었습니다.
Tuple과 struct・class의  차이점은 Tuple은 함수를 갖지 못하고, 생성자를 쓸 수 없습니다.
또한 프로토콜을 채택할 수 없고, 클래스를 상속받을 수 없습니다.
그러나 STEP1의 명세를 보았을 때, Tuple로 써도 충분할 것이라는 생각이 들어서 Tuple로 선택하게 되었습니다.
추후 STEP에서 기능이 확장된다면, struct 또는 class로 바꿀 가능성도 염두하고 있습니다.

### Fruit와 Juice의 관계에 대한 정의
`FruitType`을 정의하여, 과일의 종류를 열거형으로 표현했습니다.
`typealias`를 통해, `Fruit`에 대한 튜플을 정의했습니다. 이 튜플은 (과일의 종류, 과일의 소모 개수)를 나타냅니다.
`JuiceType`은 쥬스의 종류를 열거형으로 나타냅니다. 내부의 `ingredients` 계산프로퍼티를 이용하여,
쥬스의 레시피를 `Fruit`(과일의 종류, 과일의 소모 개수) 배열을 통해 나타냈습니다.

- **FruitType**

```swift
import Foundation

typealias Fruit = (fruitType: FruitType, count: Int)

enum FruitType {
    case strawberry
    case banana
    case pineapple
    case mango
    case kiwi
}
```

- **JuiceType**

```swift
import Foundation

enum JuiceType {
    var ingredients: [Fruit] {
        switch self {
        case .strawberryJuice:
            return [Fruit(.strawberry, 16)]
        case .bananaJuice:
            return [Fruit(.banana, 2)]
        case .kiwiJuice:
            return [Fruit(.kiwi, 3)]
        case .pineappleJuice:
            return [Fruit(.kiwi, 3)]
        case .strawberrydBananaJuice:
            return [Fruit(.strawberry, 10), Fruit(.banana, 1)]
        case .mangoJuice:
            return [Fruit(.mango, 3)]
        case .mangoKiwiJuice:
            return [Fruit(.mango, 2), Fruit(.kiwi, 1)]
        }
    }

    case strawberryJuice
    case bananaJuice
    case kiwiJuice
    case pineappleJuice
    case strawberrydBananaJuice
    case mangoJuice
    case mangoKiwiJuice
}
```

### 한 개의 과일과 여러 개의 과일 추가・삭제 방식
- 한 개의 과일같은 경우에는 `checkValidation`(과일의 개수가 음수로 떨어지는지 확인하는 함수)를 통해
과일 개수를 즉시 업데이트를 했습니다.
- 여러 개의 과일은 `JuiceType`의 `ingredients`가 `[Fruit]`를 반환하기 때문에, 이 반환 값을 파리미터로 넣었습니다.
반복문을 통해 이 배열의 내용을 확인하며, 각 과일의 재고가 충분한지 검사합니다.

- **FruitStore (한 개의 과일 처리 함수)**

```swift
func update(_ fruit: Fruit, as `operator`: ((Int, Int) -> Int)) throws {
    switch fruit.fruitType {
    case .strawberry:
        strawberry = try checkValidation(fruitCount: `operator`(strawberry, fruit.count))
    case .banana:
        banana = try checkValidation(fruitCount: `operator`(banana, fruit.count))
    case .pineapple:
        pineapple = try checkValidation(fruitCount: `operator`(pineapple, fruit.count))
    case .mango:
        mango = try checkValidation(fruitCount: `operator`(mango, fruit.count))
    case .kiwi:
        kiwi = try checkValidation(fruitCount: `operator`(kiwi, fruit.count))
    }
}
```

- **FruitStore (여러 개의 과일 처리 함수)**

```swift
func update(fruits: [Fruit], as `operator`: ((Int, Int) -> Int)) throws {
    let checkedFruits = try checkValidation(fruits: fruits, as: `operator`)
    
    for fruit in checkedFruits {
        checkedUpdate(fruit)
    }
}
```

- 매개 변수인 `operator`는 과일 개수의 추가・감소를 결정하는 연산 클로저입니다. 이런 식으로 나타낼 수 있습니다.

```swift
try fruitStore.update(fruits: juice.ingredients, as: +)
```

### 현재 과일 개수의 상태로 쥬스를 만들 수 없을 때
명세에 따르면, 딸바 주스를 만들기 위해선 딸기가 10개, 바나나가 1개가 필요합니다.
기존 코드에서는 딸바주스를 만들 때, 딸기의 재고가 11개, 그리고 바나나의 개수가 0개면
딸기의 개수가 1개로 줄어든 상태에서 딸바 주스를 못 만들게 됩니다. 즉, 과일만 소모하고 주스가 만들어지지 않습니다.
따라서, 여러 개의 과일을 업데이트를 하는 함수에서는 먼저 각 과일의 재고가 충분한지 확인한 후에 주스를 만들게 개선했습니다.

- **기존 코드**

```swift
func update(fruits: [Fruit], as option: ((UInt, UInt) -> UInt)) {
    for fruit in fruits {
        update(fruit, as: option)
    }
}

func update(_ fruit: Fruit, as option: ((UInt, UInt) -> UInt)) {
    switch fruit.fruitType {
    case .strawberry:
        strawberry = option(strawberry, fruit.count)
        print(strawberry)
    case .banana:
        banana = option(banana, fruit.count)
    case .pineapple:
        pineapple = option(pineapple, fruit.count)
    case .mango:
        mango = option(mango, fruit.count)
    case .kiwi:
        kiwi = option(kiwi, fruit.count)
    }
}
```

- **개선된 코드**
```swift
func update(fruits: [Fruit], as `operator`: ((Int, Int) -> Int)) throws {
    let checkedFruits = try checkValidation(fruits: fruits, as: `operator`)
    
    for fruit in checkedFruits {
        checkedUpdate(fruit)
    }
}

private func checkValidation(fruits: [Fruit], as `operator`: ((Int, Int) -> Int)) throws -> [Fruit] {
    var checkedFruits = [Fruit]()
    for (fruitType, count) in fruits {
        var checkedCount = 0
        switch fruitType {
        case .strawberry:
            checkedCount = try checkValidation(fruitCount: `operator`(strawberry, count))
        case .banana:
            checkedCount = try checkValidation(fruitCount: `operator`(banana, count))
        case .pineapple:
            checkedCount = try checkValidation(fruitCount: `operator`(pineapple, count))
        case .mango:
            checkedCount = try checkValidation(fruitCount: `operator`(mango, count))
        case .kiwi:
            checkedCount = try checkValidation(fruitCount: `operator`(kiwi, count))
        }
        checkedFruits.append(Fruit(fruitType, checkedCount))
    }
    return checkedFruits
}
```

### 유효성 검사를 어떻게하면 효율적으로 할 수 있을지
기존에는, 여러 개의 과일의 재고가 충분한지 검사(`checkValidation` 함수)한 후에,
한 개의 과일을 업데이트(`update` 함수)하는 함수를 호출했습니다.
이 과정에서 `checkValidation` 함수가 2번 호출되기 때문에, 비효율적이었습니다. 왜냐하면 이미 확인한 과일들을 1번 더 검사했기 때문입니다.
이 코드를 개선하여, 여러 개의 과일의 재고를 검사하는 함수가 `[Fruit]` (과일의 타입, 증감된 과일의 수)를 반환하도록 하였습니다.
이 반환값으로 `checkedUpdate` 함수를 추가해서 검사된 과일들은 바로 재고 변경이 가능하도록 했습니다.

- **기존 코드**

```swift
func update(fruits: [Fruit], as `operator`: ((Int, Int) -> Int)) throws {
    try checkValidation(fruits: fruits, as: `operator`)
    
    for fruit in fruits {
        try update(fruit, as: `operator`)
    }
}

func update(_ fruit: Fruit, as `operator`: ((Int, Int) -> Int)) throws {
    switch fruit.fruitType {
    case .strawberry:
        strawberry = try checkValidation(fruitCount: `operator`(strawberry, fruit.count))
    case .banana:
        banana = try checkValidation(fruitCount: `operator`(banana, fruit.count))
    case .pineapple:
        pineapple = try checkValidation(fruitCount: `operator`(pineapple, fruit.count))
    case .mango:
        mango = try checkValidation(fruitCount: `operator`(mango, fruit.count))
    case .kiwi:
        kiwi = try checkValidation(fruitCount: `operator`(kiwi, fruit.count))
    }
}
```

- **개선된 코드**

```swift
func update(fruits: [Fruit], as `operator`: ((Int, Int) -> Int)) throws {
    let checkedFruits = try checkValidation(fruits: fruits, as: `operator`)
    
    for fruit in checkedFruits {
        checkedUpdate(fruit)
    }
}

private func checkValidation(fruits: [Fruit], as `operator`: ((Int, Int) -> Int)) throws -> [Fruit] {
    var checkedFruits = [Fruit]()
    for (fruitType, count) in fruits {
        var checkedCount = 0
        switch fruitType {
        case .strawberry:
            checkedCount = try checkValidation(fruitCount: `operator`(strawberry, count))
        case .banana:
            checkedCount = try checkValidation(fruitCount: `operator`(banana, count))
        case .pineapple:
            checkedCount = try checkValidation(fruitCount: `operator`(pineapple, count))
        case .mango:
            checkedCount = try checkValidation(fruitCount: `operator`(mango, count))
        case .kiwi:
            checkedCount = try checkValidation(fruitCount: `operator`(kiwi, count))
        }
        checkedFruits.append(Fruit(fruitType, checkedCount))
    }
    return checkedFruits
}

private func checkedUpdate(_ checkedFruit: Fruit) {
    switch checkedFruit.fruitType {
    case .strawberry:
        strawberry = checkedFruit.count
    case .banana:
        banana = checkedFruit.count
    case .pineapple:
        pineapple = checkedFruit.count
    case .mango:
        mango = checkedFruit.count
    case .kiwi:
        kiwi = checkedFruit.count
    }
}
```

## 질문 사항
### 접근제어자에 관하여 (+ 9월 13일 14시 40분 추가)
저희 둘이 접근제어자에 대한 공부를 하고 있었는데, 답이 나오지 않아 질문사항을 남겨봅니다.
보통 다른 언어에서는 접근제어자의 범위가 점점 좁아지는 것은 허용하지만, 그 반대는 허용하지 않습니다.
반면에 Swift 공식 문서에 따르면 해당 사항을 [Guiding Principle of Access Levels](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/accesscontrol/#Guiding-Principle-of-Access-Levels)라고 하여 강제하지 않고 **권고** 하고 있습니다. 혹시 왜 이런지 알고 계신다면 답변을 남겨주시면 감사하겠습니다.
```java
// Java
protected class Test { // 컴파일 에러가 나옴. error: modifier protected not allowed here
    public int a = 19;
    private double b = 20.1;
}

public class MyClass {
    public static void main(String args[]) {
        Test test = new Test();
        System.out.println(test.a);
    }
}
```

```swift
// Swift
class InternalClass {                       // implicitly internal class
  open var PublicProperty = 0               // 컴파일 에러가 나지 않음. explicitly open class member
  public var explictInternalProperty = 0  // 컴파일 에러가 나지 않음. explicitly public class member
  fileprivate func FilePrivateMethod() {}   // explicitly file-private class member
  private func PrivateMethod() {}           // explicitly private class member
}
```