### PR TITLE
쥬스 자판기 [STEP 2] Mango, SwainYun

### DIFF
--- a/JuiceMaker/JuiceMaker/Controller/AdjustStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/AdjustStockViewController.swift
@@ -24,42 +24,39 @@ class AdjustStockViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        manageFruitStock()
-        initializeStepperValue()
+        syncStockLabels()
+        syncStepperValue()
     }
     
     @IBAction func touchStrawberryStepper(_ sender: UIStepper) {
         inventory?["딸기"] = Int(sender.value)
-        manageFruitStock()
+        syncStockLabels()
     }
     
     @IBAction func touchBananaStepper(_ sender: UIStepper) {
         inventory?["바나나"] = Int(sender.value)
-        manageFruitStock()
+        syncStockLabels()
     }
     
     @IBAction func touchKiwiStepper(_ sender: UIStepper) {
         inventory?["키위"] = Int(sender.value)
-        manageFruitStock()
+        syncStockLabels()
     }
     
     @IBAction func touchPineappleStepper(_ sender: UIStepper) {
         inventory?["파인애플"] = Int(sender.value)
-        manageFruitStock()
+        syncStockLabels()
     }
     
     @IBAction func touchMangoStepper(_ sender: UIStepper) {
         inventory?["망고"] = Int(sender.value)
-        manageFruitStock()
+        syncStockLabels()
     }
-    
-    
-    
 }
 
 // MARK: Private Methods
 extension AdjustStockViewController {
-    private func manageFruitStock() {
+    private func syncStockLabels() {
         strawberryStockLabel.text = String(inventory?["딸기"] ?? 0)
         bananaStockLabel.text = String(inventory?["바나나"] ?? 0)
         kiwiStockLabel.text = String(inventory?["키위"] ?? 0)
@@ -67,7 +64,7 @@ extension AdjustStockViewController {
         mangoStockLabel.text = String(inventory?["망고"] ?? 0)
     }
     
-    private func initializeStepperValue() {
+    private func syncStepperValue() {
         strawberryStockStepper.value = Double(inventory?["딸기"] ?? 0)
         bananaStockStepper.value = Double(inventory?["바나나"] ?? 0)
         pineappleStockStepper.value = Double(inventory?["파인애플"] ?? 0)

--- a/JuiceMaker/JuiceMaker/Controller/AdjustStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/AdjustStockViewController.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+protocol InventorySendDelegate: AnyObject {
+    func sendInventory(inventory: [String: Int])
+}
+
 class AdjustStockViewController: UIViewController {
     @IBOutlet weak var strawberryStockLabel: UILabel!
     @IBOutlet weak var bananaStockLabel: UILabel!
@@ -21,6 +25,7 @@ class AdjustStockViewController: UIViewController {
     @IBOutlet weak var mangoStockStepper: UIStepper!
     
     var inventory: [String: Int]?
+    weak var delegate: InventorySendDelegate?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -51,6 +56,14 @@ class AdjustStockViewController: UIViewController {
     @IBAction func touchMangoStepper(_ sender: UIStepper) {
         inventory?["망고"] = Int(sender.value)
         syncStockLabels()
+    }
+    
+    @IBAction func touchNavSaveButton(_ sender: UIButton) {
+        if let inventory = inventory {
+            delegate?.sendInventory(inventory: inventory)
+        }
+        
+        self.navigationController?.popViewController(animated: true)
     }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/AdjustStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/AdjustStockViewController.swift
@@ -8,9 +8,70 @@
 import UIKit
 
 class AdjustStockViewController: UIViewController {
+    @IBOutlet weak var strawberryStockLabel: UILabel!
+    @IBOutlet weak var bananaStockLabel: UILabel!
+    @IBOutlet weak var pineappleStockLabel: UILabel!
+    @IBOutlet weak var kiwiStockLabel: UILabel!
+    @IBOutlet weak var mangoStockLabel: UILabel!
+    
+    @IBOutlet weak var strawberryStockStepper: UIStepper!
+    @IBOutlet weak var bananaStockStepper: UIStepper!
+    @IBOutlet weak var pineappleStockStepper: UIStepper!
+    @IBOutlet weak var kiwiStockStepper: UIStepper!
+    @IBOutlet weak var mangoStockStepper: UIStepper!
+    
+    var inventory: [String: Int]?
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        manageFruitStock()
+        initializeStepperValue()
     }
     
+    @IBAction func touchStrawberryStepper(_ sender: UIStepper) {
+        inventory?["딸기"] = Int(sender.value)
+        manageFruitStock()
+    }
+    
+    @IBAction func touchBananaStepper(_ sender: UIStepper) {
+        inventory?["바나나"] = Int(sender.value)
+        manageFruitStock()
+    }
+    
+    @IBAction func touchKiwiStepper(_ sender: UIStepper) {
+        inventory?["키위"] = Int(sender.value)
+        manageFruitStock()
+    }
+    
+    @IBAction func touchPineappleStepper(_ sender: UIStepper) {
+        inventory?["파인애플"] = Int(sender.value)
+        manageFruitStock()
+    }
+    
+    @IBAction func touchMangoStepper(_ sender: UIStepper) {
+        inventory?["망고"] = Int(sender.value)
+        manageFruitStock()
+    }
+    
+    
+    
+}
+
+// MARK: Private Methods
+extension AdjustStockViewController {
+    private func manageFruitStock() {
+        strawberryStockLabel.text = String(inventory?["딸기"] ?? 0)
+        bananaStockLabel.text = String(inventory?["바나나"] ?? 0)
+        kiwiStockLabel.text = String(inventory?["키위"] ?? 0)
+        pineappleStockLabel.text = String(inventory?["파인애플"] ?? 0)
+        mangoStockLabel.text = String(inventory?["망고"] ?? 0)
+    }
+    
+    private func initializeStepperValue() {
+        strawberryStockStepper.value = Double(inventory?["딸기"] ?? 0)
+        bananaStockStepper.value = Double(inventory?["바나나"] ?? 0)
+        pineappleStockStepper.value = Double(inventory?["파인애플"] ?? 0)
+        kiwiStockStepper.value = Double(inventory?["키위"] ?? 0)
+        mangoStockStepper.value = Double(inventory?["망고"] ?? 0)
+    }
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -15,6 +15,8 @@ class JuiceMakerViewController: UIViewController {
     @IBOutlet weak var kiwiStockLabel: UILabel!
     @IBOutlet weak var mangoStockLabel: UILabel!
     
+    var inventory: [String: Int]?
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         self.manageFruitStock()
@@ -30,18 +32,25 @@ class JuiceMakerViewController: UIViewController {
             showAlertOutOfStock(error)
         }
     }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        guard let adjustStockViewController = segue.destination as? AdjustStockViewController
+        else { return }
+        
+        adjustStockViewController.inventory = self.inventory
+    }
 }
 
 // MARK: Private Methods
 extension JuiceMakerViewController {
     private func manageFruitStock() {
-        let inventory = juiceMaker.checkFruitStoreInventory()
+        inventory = juiceMaker.checkFruitStoreInventory()
         
-        strawberryStockLabel.text = String(inventory["딸기"] ?? 0)
-        bananaStockLabel.text = String(inventory["바나나"] ?? 0)
-        kiwiStockLabel.text = String(inventory["키위"] ?? 0)
-        pineappleStockLabel.text = String(inventory["파인애플"] ?? 0)
-        mangoStockLabel.text = String(inventory["망고"] ?? 0)
+        strawberryStockLabel.text = String(inventory?["딸기"] ?? 0)
+        bananaStockLabel.text = String(inventory?["바나나"] ?? 0)
+        kiwiStockLabel.text = String(inventory?["키위"] ?? 0)
+        pineappleStockLabel.text = String(inventory?["파인애플"] ?? 0)
+        mangoStockLabel.text = String(inventory?["망고"] ?? 0)
     }
     
     private func showAlertCompletionJuiceMaking(_ juiceName: String) {
@@ -66,6 +75,7 @@ extension JuiceMakerViewController {
         guard let adjustStockViewController = self.storyboard?.instantiateViewController(withIdentifier: "AdjustStockViewController") as? AdjustStockViewController
         else { return }
         
+        adjustStockViewController.inventory = self.inventory
         self.navigationController?.pushViewController(adjustStockViewController, animated: true)
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -19,14 +19,16 @@ class JuiceMakerViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.manageFruitStock()
+        self.loadInventory()
+        self.syncStockLabels()
     }
 
     @IBAction func makeJuice(_ sender: UIButton) {
         guard let buttonId = sender.accessibilityIdentifier else { return }
         do {
             try juiceMaker.makeJuice(juiceName: buttonId)
-            manageFruitStock()
+            self.loadInventory()
+            self.syncStockLabels()
             showAlertCompletionJuiceMaking(buttonId)
         } catch let error {
             showAlertOutOfStock(error)
@@ -43,9 +45,11 @@ class JuiceMakerViewController: UIViewController {
 
 // MARK: Private Methods
 extension JuiceMakerViewController {
-    private func manageFruitStock() {
-        inventory = juiceMaker.checkFruitStoreInventory()
-        
+    private func loadInventory() {
+        self.inventory = juiceMaker.checkFruitStoreInventory()
+    }
+    
+    private func syncStockLabels() {
         strawberryStockLabel.text = String(inventory?["딸기"] ?? 0)
         bananaStockLabel.text = String(inventory?["바나나"] ?? 0)
         kiwiStockLabel.text = String(inventory?["키위"] ?? 0)

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -35,11 +35,17 @@ class JuiceMakerViewController: UIViewController {
         }
     }
     
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        guard let adjustStockViewController = segue.destination as? AdjustStockViewController
-        else { return }
-        
-        adjustStockViewController.inventory = self.inventory
+    @IBAction func touchNavButton(_ sender: UIBarButtonItem) {
+        pushAdjustStockViewController()
+    }
+}
+
+// MARK: Delegate
+extension JuiceMakerViewController: InventorySendDelegate {
+    func sendInventory(inventory: [String: Int]) {
+        self.inventory = inventory
+        syncStockLabels()
+        juiceMaker.updateFruitStoreInventory(with: inventory)
     }
 }
 
@@ -80,6 +86,7 @@ extension JuiceMakerViewController {
         else { return }
         
         adjustStockViewController.inventory = self.inventory
+        adjustStockViewController.delegate = self
         self.navigationController?.pushViewController(adjustStockViewController, animated: true)
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -25,6 +25,7 @@ class JuiceMakerViewController: UIViewController {
 
     @IBAction func makeJuice(_ sender: UIButton) {
         guard let buttonId = sender.accessibilityIdentifier else { return }
+        
         do {
             try juiceMaker.makeJuice(juiceName: buttonId)
             self.loadInventory()

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -43,6 +43,14 @@ final class FruitStore {
 
         return itemDict
     }
+    
+    func updateInventoryStock(with inventory: [String: Int]) {
+        for item in inventory {
+            if let fruitType = FruitType(rawValue: item.key) {
+                self.inventory.updateValue(item.value, forKey: fruitType)
+            }
+        }
+    }
 }
 
 // MARK: Nested Types
@@ -98,11 +106,5 @@ extension FruitStore {
         guard let stock = self.inventory[fruit.fruitType] else { throw JuiceMakerError.invalidSelection }
         let remainStock = stock - fruit.quantity
         self.inventory[fruit.fruitType] = remainStock
-    }
-    
-    private func updateInventoryStock(with fruit: Fruit, _ quantity: Int = 1) throws {
-        guard let stock = self.inventory[fruit.fruitType] else { throw JuiceMakerError.invalidSelection }
-        let newStock = stock + quantity
-        self.inventory[fruit.fruitType] = newStock
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -17,4 +17,8 @@ struct JuiceMaker {
     func checkFruitStoreInventory() -> [String: Int] {
         return fruitStore.checkInventoryStock()
     }
+    
+    func updateFruitStoreInventory(with inventory: [String: Int]) {
+        fruitStore.updateInventoryStock(with: inventory)
+    }
 }

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -288,10 +288,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="60" translatesAutoresizingMaskIntoConstraints="NO" id="24r-3A-DZO">
-                                <rect key="frame" x="67" y="117" width="710" height="156"/>
+                                <rect key="frame" x="67" y="114" width="710" height="162"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="RKK-hT-Yac">
-                                        <rect key="frame" x="0.0" y="0.0" width="94" height="156"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="RKK-hT-Yac">
+                                        <rect key="frame" x="0.0" y="0.0" width="94" height="162"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
                                                 <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
@@ -300,22 +300,22 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                                <rect key="frame" x="0.0" y="90.666666666666657" width="94" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                                <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="touchStrawberryStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="FAD-yi-kgZ"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="sal-1d-93Y">
-                                        <rect key="frame" x="154" y="0.0" width="94" height="156"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="sal-1d-93Y">
+                                        <rect key="frame" x="154" y="0.0" width="94" height="162"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
                                                 <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
@@ -324,22 +324,22 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                                <rect key="frame" x="0.0" y="90.666666666666657" width="94" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                                <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="touchBananaStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="hch-Jj-IlF"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="CGa-mJ-o7U">
-                                        <rect key="frame" x="308" y="0.0" width="94" height="156"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="CGa-mJ-o7U">
+                                        <rect key="frame" x="308" y="0.0" width="94" height="162"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
                                                 <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
@@ -348,22 +348,22 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                                <rect key="frame" x="0.0" y="90.666666666666657" width="94" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                                <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="touchPineappleStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="IAs-lh-xFS"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="2YQ-qm-v2S">
-                                        <rect key="frame" x="462" y="0.0" width="94" height="156"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="2YQ-qm-v2S">
+                                        <rect key="frame" x="462" y="0.0" width="94" height="162"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
                                                 <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
@@ -372,22 +372,22 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                                <rect key="frame" x="0.0" y="90.666666666666657" width="94" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                                <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="touchKiwiStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="WDU-BN-dEC"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="XyD-R9-uGE">
-                                        <rect key="frame" x="616" y="0.0" width="94" height="156"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="XyD-R9-uGE">
+                                        <rect key="frame" x="616" y="0.0" width="94" height="162"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
                                                 <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
@@ -396,14 +396,14 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                                <rect key="frame" x="0.0" y="90.666666666666657" width="94" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                                <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="touchMangoStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="P7V-aH-4Ea"/>
                                                 </connections>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -245,7 +245,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <segue destination="Yu1-lM-nqp" kind="show" id="z1L-HG-5IG"/>
+                                <action selector="touchNavButton:" destination="BYZ-38-t0r" id="ikb-CO-EUe"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -287,121 +287,152 @@
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                <rect key="frame" x="590" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                <rect key="frame" x="622" y="156" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                <rect key="frame" x="580" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="touchMangoStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="P7V-aH-4Ea"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                <rect key="frame" x="429" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                <rect key="frame" x="461" y="156" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                <rect key="frame" x="410" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="touchKiwiStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="WDU-BN-dEC"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                <rect key="frame" x="271" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                <rect key="frame" x="303" y="155" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                <rect key="frame" x="261" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="touchPineappleStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="IAs-lh-xFS"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                <rect key="frame" x="165" y="73" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                <rect key="frame" x="154" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="touchBananaStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="hch-Jj-IlF"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                <rect key="frame" x="98" y="161" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                <rect key="frame" x="60" y="73" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                <rect key="frame" x="196" y="158" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                <rect key="frame" x="50" y="192" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="touchStrawberryStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="FAD-yi-kgZ"/>
-                                </connections>
-                            </stepper>
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="60" translatesAutoresizingMaskIntoConstraints="NO" id="24r-3A-DZO">
+                                <rect key="frame" x="67" y="117" width="710" height="156"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="RKK-hT-Yac">
+                                        <rect key="frame" x="0.0" y="0.0" width="94" height="156"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
+                                                <rect key="frame" x="0.0" y="90.666666666666657" width="94" height="26.333333333333329"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
+                                                <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="touchStrawberryStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="FAD-yi-kgZ"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="sal-1d-93Y">
+                                        <rect key="frame" x="154" y="0.0" width="94" height="156"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
+                                                <rect key="frame" x="0.0" y="90.666666666666657" width="94" height="26.333333333333329"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
+                                                <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="touchBananaStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="hch-Jj-IlF"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="CGa-mJ-o7U">
+                                        <rect key="frame" x="308" y="0.0" width="94" height="156"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
+                                                <rect key="frame" x="0.0" y="90.666666666666657" width="94" height="26.333333333333329"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
+                                                <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="touchPineappleStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="IAs-lh-xFS"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="2YQ-qm-v2S">
+                                        <rect key="frame" x="462" y="0.0" width="94" height="156"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
+                                                <rect key="frame" x="0.0" y="90.666666666666657" width="94" height="26.333333333333329"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
+                                                <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="touchKiwiStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="WDU-BN-dEC"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="XyD-R9-uGE">
+                                        <rect key="frame" x="616" y="0.0" width="94" height="156"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
+                                                <rect key="frame" x="0.0" y="90.666666666666657" width="94" height="26.333333333333329"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
+                                                <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="touchMangoStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="P7V-aH-4Ea"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="24r-3A-DZO" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="4HQ-S4-9e5"/>
+                            <constraint firstItem="24r-3A-DZO" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="KYZ-Nc-qIm"/>
+                        </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
+                    <navigationItem key="navigationItem" id="g4W-fY-l7r">
+                        <barButtonItem key="rightBarButtonItem" id="zqd-gs-FSA">
+                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="Prl-8b-IHf">
+                                <rect key="frame" x="590" y="0.0" width="187" height="32"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="완료"/>
+                                <connections>
+                                    <action selector="touchNavSaveButton:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="Lgq-vJ-KZE"/>
+                                </connections>
+                            </button>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <outlet property="bananaStockLabel" destination="gKu-86-RhI" id="gkC-wZ-ply"/>
                         <outlet property="bananaStockStepper" destination="O5s-2N-3iP" id="XSn-GQ-5jf"/>
@@ -417,7 +448,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1637" y="901"/>
+            <point key="canvasLocation" x="1636.4928909952605" y="900"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="cAf-jL-tPK">
@@ -439,9 +470,6 @@
             <point key="canvasLocation" x="1637" y="21"/>
         </scene>
     </scenes>
-    <inferredMetricsTieBreakers>
-        <segue reference="z1L-HG-5IG"/>
-    </inferredMetricsTieBreakers>
     <resources>
         <namedColor name="AccentColor">
             <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -243,7 +243,11 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
-                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT"/>
+                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
+                            <connections>
+                                <segue destination="Yu1-lM-nqp" kind="show" id="z1L-HG-5IG"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                     <connections>
                         <outlet property="bananaStockLabel" destination="gvk-pA-Lw5" id="Yrg-fI-YCj"/>
@@ -301,6 +305,9 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
                                 <rect key="frame" x="580" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="touchMangoStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="P7V-aH-4Ea"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
                                 <rect key="frame" x="429" y="65" width="75" height="83.666666666666671"/>
@@ -320,6 +327,9 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
                                 <rect key="frame" x="410" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="touchKiwiStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="WDU-BN-dEC"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
                                 <rect key="frame" x="271" y="65" width="75" height="83.666666666666671"/>
@@ -339,6 +349,9 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
                                 <rect key="frame" x="261" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="touchPineappleStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="IAs-lh-xFS"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
                                 <rect key="frame" x="165" y="73" width="75" height="83.666666666666671"/>
@@ -350,6 +363,9 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
                                 <rect key="frame" x="154" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="touchBananaStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="hch-Jj-IlF"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
                                 <rect key="frame" x="98" y="161" width="11.666666666666664" height="23"/>
@@ -377,12 +393,27 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                 <rect key="frame" x="50" y="192" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="touchStrawberryStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="FAD-yi-kgZ"/>
+                                </connections>
                             </stepper>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
+                    <connections>
+                        <outlet property="bananaStockLabel" destination="gKu-86-RhI" id="gkC-wZ-ply"/>
+                        <outlet property="bananaStockStepper" destination="O5s-2N-3iP" id="XSn-GQ-5jf"/>
+                        <outlet property="kiwiStockLabel" destination="ZDv-1m-HBY" id="Q2f-b7-U6n"/>
+                        <outlet property="kiwiStockStepper" destination="klA-59-Nu4" id="F1T-tb-5Af"/>
+                        <outlet property="mangoStockLabel" destination="YJI-ER-LJR" id="jJo-NK-pFI"/>
+                        <outlet property="mangoStockStepper" destination="xbn-6P-grO" id="FPy-dG-BLy"/>
+                        <outlet property="pineappleStockLabel" destination="MpT-VW-hCb" id="6ar-OB-LSM"/>
+                        <outlet property="pineappleStockStepper" destination="Rcr-xr-eqz" id="b6S-Zk-VgG"/>
+                        <outlet property="strawberryStockLabel" destination="0yV-kn-zaT" id="CH5-eT-9nM"/>
+                        <outlet property="strawberryStockStepper" destination="ZQk-f4-zrz" id="acd-3T-elx"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
@@ -408,6 +439,9 @@
             <point key="canvasLocation" x="1637" y="21"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="z1L-HG-5IG"/>
+    </inferredMetricsTieBreakers>
     <resources>
         <namedColor name="AccentColor">
             <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/README.md
+++ b/README.md
@@ -211,3 +211,36 @@ private func showAlertOutOfStock(_ error: Error) {
 >음료를 제조하기에 재고가 부족한 경우 실행되는 메서드이며 
 > * yes경우: moveAdjustStorageView를 실행합니다.
 > * no경우: alert을 닫습니다.
+
+* **pushAdjustStockViewController() 메서드**
+```swift
+private func pushAdjustStockViewController() {
+    guard let adjustStockViewController = self.storyboard?.instantiateViewController(withIdentifier: "AdjustStockViewController") as? AdjustStockViewController
+    else { return }
+
+    self.navigationController?.pushViewController(adjustStockViewController, animated: true)
+}
+```
+
+    * pushAdjustStockViewController()
+    1. navigationController를 사용하여 화면 전환시 화면 이동에 연관된 처리까지 기능해준다. UI측면에서 우측상단의 버튼클릭 시 오른쪽에서 화면이 등장하여 화면전환에 이질감이 줄어든다.
+    2. AdjustStockViewController를 인스턴스화 해 부르는 과정에서 타입 캐스팅을 시도, 추후 재고 수정 화면에서 데이터를 주고 받을 수 있도록 함
+> * present
+> 1. 뷰 위에 뷰가 한겹 올라간 것
+> 2. 세로 방향으로 전개됨
+> 3. ViewController - dismiss 메서드로 빠져나옴
+> 그래서 얼럿이나 알람같은거에 적합함?
+> 4. modalPresentationSytle로 환면 전환 스타일을 정할 수 있음
+> 
+> * push
+> 1. stack에 뷰컨트롤러를 push해서 다른 계층의 뷰로 전환
+> 2. 가로 방향으로 전개됨
+> 3. NavigationController - pop 메서드로 빠져나옴
+> 4. 원하는 스택으로 돌아갈 수 있음
+
+> * push를 사용한 이유
+> 1. ViewController는 그림과 같이 1번View는 2번 View와 2번 View 3번 View끼리는 서로 연결 되어 있지만 1번 3번 View 끼리는 서로의 존재를 모릅니다.(바로 연결되어 있지 않다. 어쨌든 2번 뷰를 거쳐야 함)
+> 2. NavigationController는 view들을 Stack에 넣어서
+> stack의 크기단위를 알기에 원하는 위치로 이동이 가능하다는 차이가 있습니다.
+> NavigationController는 view들을 Stack에 넣어서
+> stack의 크기단위를 알기에 원하는 위치로 이동이 가능하다는 차이가 있습니다.


### PR DESCRIPTION
# 쥬스 자판기 [STEP 2] Mango, SwainYun

리뷰어: @zdodev
참가자: 망고, 스웨인

안녕하세요, 소대!
쥬스 자판기 [STEP 2] PR 올립니다.

------------------------------------

## 프로젝트 구성

### JuiceMaker, FruitStore

* **쥬스와 과일의 종류를 나타내는 열거형**
```swift
private enum JuiceType: String {
    case strawberryJuice = "딸기쥬스"
    case bananaJuice = "바나나쥬스"
    case kiwiJuice = "키위쥬스"
    case pineappleJuice = "파인애플쥬스"
    case strawberryBananaMixJuice = "딸바쥬스"
    case mangoJuice = "망고쥬스"
    case mangoKiwiMixJuice = "망키쥬스"
    
    var recipe: [Fruit] {
        switch self {
        case .strawberryJuice: return [Fruit(.strawberry, 16)]
        case .bananaJuice: return [Fruit(.banana, 2)]
        case .kiwiJuice: return [Fruit(.kiwi, 3)]
        case .pineappleJuice: return [Fruit(.pineapple, 2)]
        case .strawberryBananaMixJuice: return [Fruit(.strawberry, 10), Fruit(.banana, 1)]
        case .mangoJuice: return [Fruit(.mango, 3)]
        case .mangoKiwiMixJuice: return [Fruit(.mango, 2), Fruit(.kiwi, 1)]
        }
    }
}

private enum FruitType: String, CaseIterable {
    case strawberry = "딸기"
    case banana = "바나나"
    case kiwi = "키위"
    case pineapple = "파인애플"
    case mango = "망고"
}
```

    * JuiceType, FruitType
    1. FruitStore 클래스 내에서만 사용할 것이라고 판단, FruitStore Nested Type으로 변경
    2. Storyboard의 각 버튼과 재고 현황을 표시하기 위해 Accessability ID와 매칭할 수 있도록 각 case별 RawValue 설정
> 각 버튼과 재고 라벨을 매칭할 수단으로, Restoration ID는 UI 복구 시 사용되는 것이라고 해서 사용하지 않는 것으로 의견 나눴고 버튼의 타이틀텍스트를 이용하는 것은 코드가 지저분해 보였습니다.
> 다른 방법도 많이 있겠지만 Accessability ID를 사용하기로 결정했습니다.

* **Fruit 모델**
```swift
private struct Fruit {
    let fruitType: FruitType
    let quantity: Int

    init(_ fruitType: FruitType, _ quantity: Int) {
        self.fruitType = fruitType
        self.quantity = quantity
    }
}
```
    * 주스 만드는 데 필요한 과일 종류와 수량을 가져오기 위한 구조체
    1. 마찬가지로 FruitStore 클래스 내에 위치하는 것으로 변경
    2. 개수과 종류 정보를 가지고 비교할 수 있도록 함

* **FruitStore 클래스**
```swift
final class FruitStore {
    private var inventory: [FruitType: Int]
    
    init() {
        let initialQuantity: Int = 10
        
        var inventory: [FruitType: Int] = [:]
        
        for fruitType in FruitType.allCases {
            inventory[fruitType] = initialQuantity
        }
        
        self.inventory = inventory
    }
}
```

    * FruitStore class
    1. 과일 종류별 재고를 쉽게 다루기 위해 Dictionary가 적절한 것 같아 Dictionary로 변경
    2. 초기값 설정 시 반복되는 숫자 '10'을 다루기 위해 init 작업에 추가
    
* **receiveOrder() 메서드**
```swift
func receiveOrder(juiceName: String) throws {
    guard let juice = JuiceType(rawValue: juiceName) 
    else { throw JuiceMakerError.invalidSelection }
    let recipe = juice.recipe
    
    for ingredient in recipe {
        try validateStock(with: ingredient)
    }
    
    for ingredient in recipe {
        try updateInventoryStock(with: ingredient)
    }
}
```

    * receiveOrder()
    1. 버튼 입력으로 받아온 juiceName(Accessability ID로 등록되어있던)으로 JuiceType이 있는지 확인, 
    2. 있다면 그 쥬스의 레시피를 확인, 
    3. 레시피에서 요구한 과일 및 수량과 현재 재고를 확인, 제조 가능하다면 사용한만큼 재고 조정
> 변경 전 메서드에서, 재고 조정 시마다 관련 함수를 호출해야할 때 반복되는 코드를 여러번 작성하는 것이 마음에 들지 않았는데 반복문 사용으로 이를 해결했습니다.

* **유효성 검사, 재고 변경**
```swift
private func validateStock(with fruit: Fruit) throws {
    guard let stock = self.inventory[fruit.fruitType], stock - fruit.quantity >= 0 else { throw JuiceMakerError.outOfStock }
}

private func updateInventoryStock(with fruit: Fruit) throws {
    guard let stock = self.inventory[fruit.fruitType] else { throw JuiceMakerError.invalidSelection }
    let remainStock = stock - fruit.quantity
    self.inventory[fruit.fruitType] = remainStock
}
```

    * 유효성 검사, 재고 변경
    1. validateStock(): 현재 재고 확인, 요구 수량을 빼고도 재고가 0 이상이면 통과, 아니면 outOfStock 에러 전파
    2. updateInventoryStock(): 요구 수량만큼 빼고 변경된 값으로 재고 갱신
> 재고 부분을 Dictionary로 변경하면서 관련 메서드들도 조금씩 바꾸어 주었습니다.

---------------------------------------

### JuiceMakerViewController

* **makeJuice() 메서드**
```swift
@IBAction func makeJuice(_ sender: UIButton) {
    guard let buttonId = sender.accessibilityIdentifier 
    else { return }
    do {
        try juiceMaker.makeJuice(juiceName: buttonId)
        manageFruitStock()
        showAlertCompletionJuiceMaking(buttonId)
    } catch let error {
        showAlertOutOfStock(error)
    }
}
```

    * makeJuice()
    1. Accessability ID를 통해 어떤 버튼이 입력되었는지 식별
    2. 모델 쪽 메서드와 연결, 재고 확인 및 수정 작업 등이 이루어짐
    3. 성공 여부에 따라 적절한 얼럿 표시
> VC의 makeJuice 메서드와 Model의 makeJuice 메서드 이름이 겹치는데, 이럴 경우 어떤 문제가 발생할 수 있을까요?

* **manageFruitStock() 메서드**
```swift
private func manageFruitStock() {
    let inventory = juiceMaker.checkFruitStoreInventory()

    strawberryStockLabel.text = String(inventory["딸기"] ?? 0)
    bananaStockLabel.text = String(inventory["바나나"] ?? 0)
    kiwiStockLabel.text = String(inventory["키위"] ?? 0)
    pineappleStockLabel.text = String(inventory["파인애플"] ?? 0)
    mangoStockLabel.text = String(inventory["망고"] ?? 0)
}
```

    * manageFruitStock()
    1. 과일명과 재고 정보를 읽어옴
    2. 재고 수량을 표시하는 라벨에 현재 재고 표시
> 쥬스 주문 후 변경된 재고로 새로고쳐주기 위해 makeJuice 메서드 내에서 다시 호출합니다.
> 또 최초 뷰 렌더링 시 표시될 수 있도록 viewDidLoad() 내에서 호출합니다.


* **showAlertCompletionJuiceMaking() 메서드**
```swift
private func showAlertCompletionJuiceMaking(_ juiceName: String) {
    let alert = UIAlertController(title: "\(juiceName) 쥬스 나왔습니다! 맛있게 드세요!", message: nil, preferredStyle: .alert)
    let yes = UIAlertAction(title: "감사합니다!", style: .default)
    alert.addAction(yes)
    present(alert, animated: true, completion: nil)
}
```

    * showAlertCompletionJuiceMaking()
    1. 쥬스 만들기에 성공할 경우 얼럿 표시
    2. 얼럿을 닫을 수 있는 버튼 추가
> 주스 재고가 있을 경우나 실행되는 메서드 입니다. 주문한 주스 이름이 alert해주고 창을 닫을 수 있도록 "yes" UIAlertAction을 추가해 주었습니다.

* **showAlertOutOfStock() 메서드**
```swift
private func showAlertOutOfStock(_ error: Error) {
    let alert = UIAlertController(title: "\(error)", message: nil, preferredStyle: .alert)
    let yes = UIAlertAction(title: "예", style: .default) { _ in
        self.moveAdjustStorageView()
    }
    let no = UIAlertAction(title: "아니오", style: .destructive, handler: nil)
    alert.addAction(yes)
    alert.addAction(no)
    present(alert, animated: true, completion: nil)
}
```

    * showAlertOutOfStock()
    1. 재고 부족으로 전파된 JuiceMakerError.outOfStock 상황에 대한 처리
    2. 재고 설정 뷰로 이동하거나 얼럿을 닫을 수 있는 버튼 두개 추가
>음료를 제조하기에 재고가 부족한 경우 실행되는 메서드이며 
> * yes경우: moveAdjustStorageView를 실행합니다.
> * no경우: alert을 닫습니다.

* **pushAdjustStockViewController() 메서드**
```swift
private func pushAdjustStockViewController() {
    guard let adjustStockViewController = self.storyboard?.instantiateViewController(withIdentifier: "AdjustStockViewController") as? AdjustStockViewController
    else { return }

    self.navigationController?.pushViewController(adjustStockViewController, animated: true)
}
```

    * pushAdjustStockViewController()
    1. navigationController를 사용하여 화면 전환시 화면 이동에 연관된 처리까지 기능해준다. UI측면에서 우측상단의 버튼클릭 시 오른쪽에서 화면이 등장하여 화면전환에 이질감이 줄어든다.
    2. AdjustStockViewController를 인스턴스화 해 부르는 과정에서 타입 캐스팅을 시도, 추후 재고 수정 화면에서 데이터를 주고 받을 수 있도록 함
> * present
> 1. 뷰 위에 뷰가 한겹 올라간 것
> 2. 세로 방향으로 전개됨
> 3. ViewController - dismiss 메서드로 빠져나옴
> 그래서 얼럿이나 알람같은거에 적합함?
> 4. modalPresentationSytle로 환면 전환 스타일을 정할 수 있음
> 
> * push
> 1. stack에 뷰컨트롤러를 push해서 다른 계층의 뷰로 전환
> 2. 가로 방향으로 전개됨
> 3. NavigationController - pop 메서드로 빠져나옴
> 4. 원하는 스택으로 돌아갈 수 있음

> * push를 사용한 이유
> 1. ViewController는 그림과 같이 1번View는 2번 View와 2번 View 3번 View끼리는 서로 연결 되어 있지만 1번 3번 View 끼리는 서로의 존재를 모릅니다.(바로 연결되어 있지 않다. 어쨌든 2번 뷰를 거쳐야 함)
> 2. NavigationController는 view들을 Stack에 넣어서
> stack의 크기단위를 알기에 원하는 위치로 이동이 가능하다는 차이가 있습니다.
> NavigationController는 view들을 Stack에 넣어서
> stack의 크기단위를 알기에 원하는 위치로 이동이 가능하다는 차이가 있습니다.