### PR TITLE
쥬스자판기 [STEP 3] Mond, Rarla

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		4B56B0032AB3FBB0000FE39D /* Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B56B0022AB3FBB0000FE39D /* Type.swift */; };
+		B838C8B02AB9803D0016343C /* EditStoreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B838C8AF2AB9803D0016343C /* EditStoreViewController.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
@@ -21,6 +22,7 @@
 
 /* Begin PBXFileReference section */
 		4B56B0022AB3FBB0000FE39D /* Type.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Type.swift; sourceTree = "<group>"; };
+		B838C8AF2AB9803D0016343C /* EditStoreViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditStoreViewController.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -51,6 +53,7 @@
 				C73DAF36255D0CDD00020D38 /* AppDelegate.swift */,
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
 				C73DAF3A255D0CDD00020D38 /* ViewController.swift */,
+				B838C8AF2AB9803D0016343C /* EditStoreViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -175,6 +178,7 @@
 			files = (
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
 				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
+				B838C8B02AB9803D0016343C /* EditStoreViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
 				4B56B0032AB3FBB0000FE39D /* Type.swift in Sources */,

--- a/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
@@ -9,14 +9,14 @@ import UIKit
 
 class EditStoreViewController: UIViewController {
   
-  var delegate: UpdateProtocol?
+  var delegate: ViewControllerDelegate?
   let store = FruitStore.shared
   
-  var strawberry: String?
-  var banana: String?
-  var pineapple: String?
-  var kiwi: String?
-  var mango: String?
+  var strawberryValue: String?
+  var bananaValue: String?
+  var pineappleValue: String?
+  var kiwiValue: String?
+  var mangoValue: String?
   
   @IBOutlet weak var strawberryNumberLabel: UILabel!
   @IBOutlet weak var bananaNumberLabel: UILabel!
@@ -37,39 +37,48 @@ class EditStoreViewController: UIViewController {
   }
   
   func setNumberLabel() {
-    strawberryNumberLabel.text = strawberry
-    bananaNumberLabel.text = banana
-    pineappleNumberLabel.text = pineapple
-    kiwiNumberLabel.text = kiwi
-    mangoNumberLabel.text = mango
+    strawberryNumberLabel.text = strawberryValue
+    bananaNumberLabel.text = bananaValue
+    pineappleNumberLabel.text = pineappleValue
+    kiwiNumberLabel.text = kiwiValue
+    mangoNumberLabel.text = mangoValue
+  }
+  
+  func setMinimumValue() {
+    let fruitStepperList: [UILabel: UIStepper] = [strawberryNumberLabel: strawberryStepper, bananaNumberLabel: bananaStepper, pineappleNumberLabel: pineappleStepper, kiwiNumberLabel: kiwiStepper, mangoNumberLabel: mangoStepper]
+    
+    for (fruitLabel, fruitStepper) in fruitStepperList {
+      guard let stringFruitValue = fruitLabel.text else { return }
+      guard let doubleFruitValue = Double(stringFruitValue) else { return }
+      fruitStepper.minimumValue = -doubleFruitValue
+    }
   }
   
   @IBAction func dismissButtonTapped(_ sender: UIButton) {
-    self.delegate?.update()
+    self.delegate?.updateData()
     self.dismiss(animated: true)
   }
   
   @IBAction func stepperButtonTapped(_ sender: UIStepper) {
-    let tag = sender.tag
-    switch tag {
+    switch sender.tag {
     case 0:
-      let changeNumber = getChangeNumber(fruitNumber: strawberry, changeValue: sender.value)
+      let changeNumber = getChangeNumber(fruitNumber: strawberryValue, changeValue: sender.value)
       strawberryNumberLabel.text = changeNumber.description
       store.update(fruitName: .strawberry, number: changeNumber)
     case 1:
-      let changeNumber = getChangeNumber(fruitNumber: banana, changeValue: sender.value)
+      let changeNumber = getChangeNumber(fruitNumber: bananaValue, changeValue: sender.value)
       bananaNumberLabel.text = changeNumber.description
       store.update(fruitName: .banana, number: changeNumber)
     case 2:
-      let changeNumber = getChangeNumber(fruitNumber: pineapple, changeValue: sender.value)
+      let changeNumber = getChangeNumber(fruitNumber: pineappleValue, changeValue: sender.value)
       pineappleNumberLabel.text = changeNumber.description
       store.update(fruitName: .pineapple, number: changeNumber)
     case 3:
-      let changeNumber = getChangeNumber(fruitNumber: kiwi, changeValue: sender.value)
+      let changeNumber = getChangeNumber(fruitNumber: kiwiValue, changeValue: sender.value)
       kiwiNumberLabel.text = changeNumber.description
       store.update(fruitName: .kiwi, number: changeNumber)
     case 4:
-      let changeNumber = getChangeNumber(fruitNumber: mango, changeValue: sender.value)
+      let changeNumber = getChangeNumber(fruitNumber: mangoValue, changeValue: sender.value)
       mangoNumberLabel.text = changeNumber.description
       store.update(fruitName: .mango, number: changeNumber)
     default:
@@ -78,18 +87,8 @@ class EditStoreViewController: UIViewController {
   }
   
   func getChangeNumber(fruitNumber: String?, changeValue: Double) -> Int {
-    guard let fruitString = fruitNumber else { return 0 }
-    guard let fruitNumber = Int(fruitString) else { return 0 }
-    return fruitNumber + Int(changeValue)
-  }
-  
-  func setMinimumValue() {
-    let fruitStepperList: [UILabel: UIStepper] = [strawberryNumberLabel: strawberryStepper, bananaNumberLabel: bananaStepper, pineappleNumberLabel: pineappleStepper, kiwiNumberLabel: kiwiStepper, mangoNumberLabel: mangoStepper]
-    
-    for (fruitLabel, fruitStepper) in fruitStepperList {
-      guard let fruitString = fruitLabel.text else { return }
-      guard let fruitdouble = Double(fruitString) else { return }
-      fruitStepper.minimumValue = -fruitdouble
-    }
+    guard let stringFruitValue = fruitNumber else { return 0 }
+    guard let intFruitValue = Int(stringFruitValue) else { return 0 }
+    return intFruitValue + Int(changeValue)
   }
 }

--- a/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class EditStoreViewController: UIViewController {
   
+  var delegate: UpdateProtocol?
   let store = FruitStore.shared
   
   var strawberry: String?
@@ -16,8 +17,6 @@ class EditStoreViewController: UIViewController {
   var pineapple: String?
   var kiwi: String?
   var mango: String?
-  
-  var delegate: UpdateProtocol?
   
   @IBOutlet weak var strawberryNumberLabel: UILabel!
   @IBOutlet weak var bananaNumberLabel: UILabel!

--- a/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class EditStoreViewController: UIViewController {
   
-  var delegate: DismissEditStoreViewDelegate?
+  weak var delegate: DismissEditStoreViewDelegate?
   
   var strawberryValue: String?
   var bananaValue: String?

--- a/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class EditStoreViewController: UIViewController {
   
-  var delegate: ViewControllerDelegate?
+  var delegate: DismissEditStoreViewDelegate?
   private let store = FruitStore.shared
   
   var strawberryValue: String?

--- a/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
@@ -1,0 +1,32 @@
+//
+//  EditStoreViewController.swift
+//  JuiceMaker
+//
+//  Created by YEJI on 2023/09/19.
+//
+
+import UIKit
+
+class EditStoreViewController: UIViewController {
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    // Do any additional setup after loading the view.
+  }
+  
+  @IBAction func dismissButtonTapped(_ sender: UIBarButtonItem) {
+    self.dismiss(animated: true)
+  }
+  
+  /*
+   // MARK: - Navigation
+   
+   // In a storyboard-based application, you will often want to do a little preparation before navigation
+   override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+   // Get the new view controller using segue.destination.
+   // Pass the selected object to the new view controller.
+   }
+   */
+  
+}

--- a/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
@@ -46,7 +46,6 @@ class EditStoreViewController: UIViewController {
   
   @IBAction func dismissButtonTapped(_ sender: UIButton) {
     self.delegate?.update()
-    
     self.dismiss(animated: true)
   }
   
@@ -54,23 +53,23 @@ class EditStoreViewController: UIViewController {
     let tag = sender.tag
     switch tag {
     case 0:
-      let changeNumber = getChangeNumber(fruitName: strawberry, changeValue: sender.value)
+      let changeNumber = getChangeNumber(fruitNumber: strawberry, changeValue: sender.value)
       strawberryNumberLabel.text = changeNumber.description
       store.update(fruitName: .strawberry, number: changeNumber)
     case 1:
-      let changeNumber = getChangeNumber(fruitName: banana, changeValue: sender.value)
+      let changeNumber = getChangeNumber(fruitNumber: banana, changeValue: sender.value)
       bananaNumberLabel.text = changeNumber.description
       store.update(fruitName: .banana, number: changeNumber)
     case 2:
-      let changeNumber = getChangeNumber(fruitName: pineapple, changeValue: sender.value)
+      let changeNumber = getChangeNumber(fruitNumber: pineapple, changeValue: sender.value)
       pineappleNumberLabel.text = changeNumber.description
       store.update(fruitName: .pineapple, number: changeNumber)
     case 3:
-      let changeNumber = getChangeNumber(fruitName: kiwi, changeValue: sender.value)
+      let changeNumber = getChangeNumber(fruitNumber: kiwi, changeValue: sender.value)
       kiwiNumberLabel.text = changeNumber.description
       store.update(fruitName: .kiwi, number: changeNumber)
     case 4:
-      let changeNumber = getChangeNumber(fruitName: mango, changeValue: sender.value)
+      let changeNumber = getChangeNumber(fruitNumber: mango, changeValue: sender.value)
       mangoNumberLabel.text = changeNumber.description
       store.update(fruitName: .mango, number: changeNumber)
     default:
@@ -78,32 +77,19 @@ class EditStoreViewController: UIViewController {
     }
   }
   
-  func getChangeNumber(fruitName: String?, changeValue: Double) -> Int {
-    guard let fruitString = fruitName else { return 0 }
+  func getChangeNumber(fruitNumber: String?, changeValue: Double) -> Int {
+    guard let fruitString = fruitNumber else { return 0 }
     guard let fruitNumber = Int(fruitString) else { return 0 }
     return fruitNumber + Int(changeValue)
   }
   
   func setMinimumValue() {
-    guard let strawberryString = strawberry else { return }
-    guard let strawberryDouble = Double(strawberryString) else { return }
-    strawberryStepper.minimumValue = -strawberryDouble
+    let fruitStepperList: [UILabel: UIStepper] = [strawberryNumberLabel: strawberryStepper, bananaNumberLabel: bananaStepper, pineappleNumberLabel: pineappleStepper, kiwiNumberLabel: kiwiStepper, mangoNumberLabel: mangoStepper]
     
-    guard let bananaString = banana else { return }
-    guard let bananaDouble = Double(bananaString) else { return }
-    bananaStepper.minimumValue = -bananaDouble
-    
-    guard let pineappleString = pineapple else { return }
-    guard let pineappleDouble = Double(pineappleString) else { return }
-    pineappleStepper.minimumValue = -pineappleDouble
-    
-    guard let kiwiString = kiwi else { return }
-    guard let kiwiDouble = Double(kiwiString) else { return }
-    kiwiStepper.minimumValue = -kiwiDouble
-    
-    guard let mangoString = mango else { return }
-    guard let mangoDouble = Double(mangoString) else { return }
-    mangoStepper.minimumValue = -mangoDouble
+    for (fruitLabel, fruitStepper) in fruitStepperList {
+      guard let fruitString = fruitLabel.text else { return }
+      guard let fruitdouble = Double(fruitString) else { return }
+      fruitStepper.minimumValue = -fruitdouble
+    }
   }
-  
 }

--- a/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
@@ -9,12 +9,32 @@ import UIKit
 
 class EditStoreViewController: UIViewController {
   
+  var strawberry: String?
+  var banana: String?
+  var pineapple: String?
+  var kiwi: String?
+  var mango: String?
+  
+  @IBOutlet weak var strawberryNumberLabel: UILabel!
+  @IBOutlet weak var bananaNumberLabel: UILabel!
+  @IBOutlet weak var pineappleNumberLabel: UILabel!
+  @IBOutlet weak var kiwiNumberLabel: UILabel!
+  @IBOutlet weak var mangoNumberLabel: UILabel!
+  
   override func viewDidLoad() {
     super.viewDidLoad()
+    setNumberLabel()
   }
   
   @IBAction func dismissButtonTapped(_ sender: UIButton) {
     self.dismiss(animated: true)
   }
-
+  
+  func setNumberLabel() {
+    strawberryNumberLabel.text = strawberry
+    bananaNumberLabel.text = banana
+    pineappleNumberLabel.text = pineapple
+    kiwiNumberLabel.text = kiwi
+    mangoNumberLabel.text = mango
+  }
 }

--- a/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
@@ -7,10 +7,10 @@
 
 import UIKit
 
-class EditStoreViewController: UIViewController {
+final class EditStoreViewController: UIViewController {
   
   var delegate: ViewControllerDelegate?
-  let store = FruitStore.shared
+  private let store = FruitStore.shared
   
   var strawberryValue: String?
   var bananaValue: String?
@@ -18,17 +18,17 @@ class EditStoreViewController: UIViewController {
   var kiwiValue: String?
   var mangoValue: String?
   
-  @IBOutlet weak var strawberryNumberLabel: UILabel!
-  @IBOutlet weak var bananaNumberLabel: UILabel!
-  @IBOutlet weak var pineappleNumberLabel: UILabel!
-  @IBOutlet weak var kiwiNumberLabel: UILabel!
-  @IBOutlet weak var mangoNumberLabel: UILabel!
+  @IBOutlet weak private var strawberryNumberLabel: UILabel!
+  @IBOutlet weak private var bananaNumberLabel: UILabel!
+  @IBOutlet weak private var pineappleNumberLabel: UILabel!
+  @IBOutlet weak private var kiwiNumberLabel: UILabel!
+  @IBOutlet weak private var mangoNumberLabel: UILabel!
   
-  @IBOutlet weak var strawberryStepper: UIStepper!
-  @IBOutlet weak var bananaStepper: UIStepper!
-  @IBOutlet weak var pineappleStepper: UIStepper!
-  @IBOutlet weak var kiwiStepper: UIStepper!
-  @IBOutlet weak var mangoStepper: UIStepper!
+  @IBOutlet weak private var strawberryStepper: UIStepper!
+  @IBOutlet weak private var bananaStepper: UIStepper!
+  @IBOutlet weak private var pineappleStepper: UIStepper!
+  @IBOutlet weak private var kiwiStepper: UIStepper!
+  @IBOutlet weak private var mangoStepper: UIStepper!
   
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -36,7 +36,7 @@ class EditStoreViewController: UIViewController {
     setMinimumValue()
   }
   
-  func setNumberLabel() {
+  private func setNumberLabel() {
     strawberryNumberLabel.text = strawberryValue
     bananaNumberLabel.text = bananaValue
     pineappleNumberLabel.text = pineappleValue
@@ -44,7 +44,7 @@ class EditStoreViewController: UIViewController {
     mangoNumberLabel.text = mangoValue
   }
   
-  func setMinimumValue() {
+  private func setMinimumValue() {
     let fruitStepperList: [UILabel: UIStepper] = [strawberryNumberLabel: strawberryStepper, bananaNumberLabel: bananaStepper, pineappleNumberLabel: pineappleStepper, kiwiNumberLabel: kiwiStepper, mangoNumberLabel: mangoStepper]
     
     for (fruitLabel, fruitStepper) in fruitStepperList {
@@ -54,12 +54,12 @@ class EditStoreViewController: UIViewController {
     }
   }
   
-  @IBAction func dismissButtonTapped(_ sender: UIButton) {
+  @IBAction private func dismissButtonTapped(_ sender: UIButton) {
     self.delegate?.updateData()
     self.dismiss(animated: true)
   }
   
-  @IBAction func stepperButtonTapped(_ sender: UIStepper) {
+  @IBAction private func stepperButtonTapped(_ sender: UIStepper) {
     switch sender.tag {
     case 0:
       let changeNumber = getChangeNumber(fruitNumber: strawberryValue, changeValue: sender.value)
@@ -86,7 +86,7 @@ class EditStoreViewController: UIViewController {
     }
   }
   
-  func getChangeNumber(fruitNumber: String?, changeValue: Double) -> Int {
+  private func getChangeNumber(fruitNumber: String?, changeValue: Double) -> Int {
     guard let stringFruitValue = fruitNumber else { return 0 }
     guard let intFruitValue = Int(stringFruitValue) else { return 0 }
     return intFruitValue + Int(changeValue)

--- a/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
@@ -15,7 +15,7 @@ class EditStoreViewController: UIViewController {
     // Do any additional setup after loading the view.
   }
   
-  @IBAction func dismissButtonTapped(_ sender: UIBarButtonItem) {
+  @IBAction func dismissButtonTapped(_ sender: UIButton) {
     self.dismiss(animated: true)
   }
   

--- a/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
@@ -13,11 +13,7 @@ final class EditStoreViewController: UIViewController {
   
   private let store = FruitStore.shared
   
-  lazy private var strawberryNumber = store.getNum(fruitName: .strawberry)
-  lazy private var bananaNumber = store.getNum(fruitName: .banana)
-  lazy private var pineappleNumber = store.getNum(fruitName: .pineapple)
-  lazy private var kiwiNumber = store.getNum(fruitName: .kiwi)
-  lazy private var mangoNumber = store.getNum(fruitName: .mango)
+  @IBOutlet var numberLabelCollection: [UILabel]!
   
   @IBOutlet weak private var strawberryNumberLabel: UILabel!
   @IBOutlet weak private var bananaNumberLabel: UILabel!
@@ -38,11 +34,10 @@ final class EditStoreViewController: UIViewController {
   }
   
   private func setNumberLabel() {
-    strawberryNumberLabel.text = strawberryNumber.description
-    bananaNumberLabel.text = bananaNumber.description
-    pineappleNumberLabel.text = pineappleNumber.description
-    kiwiNumberLabel.text = kiwiNumber.description
-    mangoNumberLabel.text = mangoNumber.description
+    for numberLabel in numberLabelCollection {
+      guard let currentFruitName = Fruit(rawValue: numberLabel.tag) else { return }
+      numberLabel.text = store.getNum(fruitName: currentFruitName).description
+    }
   }
   
   private func setMinimumValue() {
@@ -56,34 +51,25 @@ final class EditStoreViewController: UIViewController {
   }
   
   @IBAction private func dismissButtonTapped(_ sender: UIButton) {
+    for numberLabel in numberLabelCollection {
+      guard let stringNumberValue = numberLabel.text else { return }
+      guard let currentFruitValue = Int(stringNumberValue) else { return }
+      guard let currentFruitName = Fruit(rawValue: numberLabel.tag) else { return }
+      store.update(fruitName: currentFruitName, number: currentFruitValue)
+    }
+    
     self.delegate?.updateData()
     self.dismiss(animated: true)
   }
   
   @IBAction private func stepperButtonTapped(_ sender: UIStepper) {
-    switch sender.tag {
-    case 0:
-      let changeNumber = strawberryNumber + Int(sender.value)
-      strawberryNumberLabel.text = changeNumber.description
-      store.update(fruitName: .strawberry, number: changeNumber)
-    case 1:
-      let changeNumber = bananaNumber + Int(sender.value)
-      bananaNumberLabel.text = changeNumber.description
-      store.update(fruitName: .banana, number: changeNumber)
-    case 2:
-      let changeNumber = pineappleNumber + Int(sender.value)
-      pineappleNumberLabel.text = changeNumber.description
-      store.update(fruitName: .pineapple, number: changeNumber)
-    case 3:
-      let changeNumber = kiwiNumber + Int(sender.value)
-      kiwiNumberLabel.text = changeNumber.description
-      store.update(fruitName: .kiwi, number: changeNumber)
-    case 4:
-      let changeNumber = mangoNumber + Int(sender.value)
-      mangoNumberLabel.text = changeNumber.description
-      store.update(fruitName: .mango, number: changeNumber)
-    default:
-      return
+    guard let currentFruitName = Fruit(rawValue: sender.tag) else { return }
+    let changeNumber = store.getNum(fruitName: currentFruitName) + Int(sender.value)
+    
+    for numberLabel in numberLabelCollection {
+      if numberLabel.tag == sender.tag {
+        numberLabel.text = changeNumber.description
+      }
     }
   }
 }

--- a/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
@@ -34,15 +34,25 @@ class EditStoreViewController: UIViewController {
     let tag = sender.tag
     switch tag {
     case 0:
-      strawberryNumberLabel.text = Int(sender.value).description
+      guard let strawberryString = strawberry else { return }
+      guard let strawberryNumber = Int(strawberryString) else { return }
+      strawberryNumberLabel.text = (strawberryNumber + Int(sender.value)).description
     case 1:
-      bananaNumberLabel.text = Int(sender.value).description
+      guard let bananaString = banana else { return }
+      guard let bananaNumber = Int(bananaString) else { return }
+      bananaNumberLabel.text = (bananaNumber + Int(sender.value)).description
     case 2:
-      pineappleNumberLabel.text = Int(sender.value).description
+      guard let pineappleString = pineapple else { return }
+      guard let pineappleNumber = Int(pineappleString) else { return }
+      pineappleNumberLabel.text = (pineappleNumber + Int(sender.value)).description
     case 3:
-      kiwiNumberLabel.text = Int(sender.value).description
+      guard let kiwiString = kiwi else { return }
+      guard let kiwiNumber = Int(kiwiString) else { return }
+      kiwiNumberLabel.text = (kiwiNumber + Int(sender.value)).description
     case 4:
-      mangoNumberLabel.text = Int(sender.value).description
+      guard let mangoString = mango else { return }
+      guard let mangoNumber = Int(mangoString) else { return }
+      mangoNumberLabel.text = (mangoNumber + Int(sender.value)).description
     default:
       return
     }

--- a/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
@@ -11,22 +11,10 @@ class EditStoreViewController: UIViewController {
   
   override func viewDidLoad() {
     super.viewDidLoad()
-    
-    // Do any additional setup after loading the view.
   }
   
   @IBAction func dismissButtonTapped(_ sender: UIButton) {
     self.dismiss(animated: true)
   }
-  
-  /*
-   // MARK: - Navigation
-   
-   // In a storyboard-based application, you will often want to do a little preparation before navigation
-   override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-   // Get the new view controller using segue.destination.
-   // Pass the selected object to the new view controller.
-   }
-   */
-  
+
 }

--- a/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
@@ -30,6 +30,25 @@ class EditStoreViewController: UIViewController {
     self.dismiss(animated: true)
   }
   
+  @IBAction func stepperButtonTapped(_ sender: UIStepper) {
+    let tag = sender.tag
+    switch tag {
+    case 0:
+      strawberryNumberLabel.text = Int(sender.value).description
+    case 1:
+      bananaNumberLabel.text = Int(sender.value).description
+    case 2:
+      pineappleNumberLabel.text = Int(sender.value).description
+    case 3:
+      kiwiNumberLabel.text = Int(sender.value).description
+    case 4:
+      mangoNumberLabel.text = Int(sender.value).description
+    default:
+      return
+    }
+  }
+  
+  
   func setNumberLabel() {
     strawberryNumberLabel.text = strawberry
     bananaNumberLabel.text = banana

--- a/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
@@ -9,11 +9,15 @@ import UIKit
 
 class EditStoreViewController: UIViewController {
   
+  let store = FruitStore.shared
+  
   var strawberry: String?
   var banana: String?
   var pineapple: String?
   var kiwi: String?
   var mango: String?
+  
+  var delegate: UpdateProtocol?
   
   @IBOutlet weak var strawberryNumberLabel: UILabel!
   @IBOutlet weak var bananaNumberLabel: UILabel!
@@ -34,6 +38,8 @@ class EditStoreViewController: UIViewController {
   }
   
   @IBAction func dismissButtonTapped(_ sender: UIButton) {
+    self.delegate?.update()
+    
     self.dismiss(animated: true)
   }
   
@@ -43,23 +49,33 @@ class EditStoreViewController: UIViewController {
     case 0:
       guard let strawberryString = strawberry else { return }
       guard let strawberryNumber = Int(strawberryString) else { return }
-      strawberryNumberLabel.text = (strawberryNumber + Int(sender.value)).description
+      let strawberryChangeNumber = strawberryNumber + Int(sender.value)
+      strawberryNumberLabel.text = strawberryChangeNumber.description
+      store.update(fruitName: .strawberry, number: strawberryChangeNumber)
     case 1:
       guard let bananaString = banana else { return }
       guard let bananaNumber = Int(bananaString) else { return }
-      bananaNumberLabel.text = (bananaNumber + Int(sender.value)).description
+      let bananaChangeNumber = bananaNumber + Int(sender.value)
+      bananaNumberLabel.text = bananaChangeNumber.description
+      store.update(fruitName: .banana, number: bananaChangeNumber)
     case 2:
       guard let pineappleString = pineapple else { return }
       guard let pineappleNumber = Int(pineappleString) else { return }
-      pineappleNumberLabel.text = (pineappleNumber + Int(sender.value)).description
+      let pineappleChangeNumber = pineappleNumber + Int(sender.value)
+      pineappleNumberLabel.text = pineappleChangeNumber.description
+      store.update(fruitName: .pineapple, number: pineappleChangeNumber)
     case 3:
       guard let kiwiString = kiwi else { return }
       guard let kiwiNumber = Int(kiwiString) else { return }
-      kiwiNumberLabel.text = (kiwiNumber + Int(sender.value)).description
+      let kiwiChangeNumber = kiwiNumber + Int(sender.value)
+      kiwiNumberLabel.text = kiwiChangeNumber.description
+      store.update(fruitName: .kiwi, number: kiwiChangeNumber)
     case 4:
       guard let mangoString = mango else { return }
       guard let mangoNumber = Int(mangoString) else { return }
-      mangoNumberLabel.text = (mangoNumber + Int(sender.value)).description
+      let mangoChangeNumber = mangoNumber + Int(sender.value)
+      mangoNumberLabel.text = mangoChangeNumber.description
+      store.update(fruitName: .mango, number: mangoChangeNumber)
     default:
       return
     }

--- a/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
@@ -36,6 +36,14 @@ class EditStoreViewController: UIViewController {
     setMinimumValue()
   }
   
+  func setNumberLabel() {
+    strawberryNumberLabel.text = strawberry
+    bananaNumberLabel.text = banana
+    pineappleNumberLabel.text = pineapple
+    kiwiNumberLabel.text = kiwi
+    mangoNumberLabel.text = mango
+  }
+  
   @IBAction func dismissButtonTapped(_ sender: UIButton) {
     self.delegate?.update()
     
@@ -46,46 +54,34 @@ class EditStoreViewController: UIViewController {
     let tag = sender.tag
     switch tag {
     case 0:
-      guard let strawberryString = strawberry else { return }
-      guard let strawberryNumber = Int(strawberryString) else { return }
-      let strawberryChangeNumber = strawberryNumber + Int(sender.value)
-      strawberryNumberLabel.text = strawberryChangeNumber.description
-      store.update(fruitName: .strawberry, number: strawberryChangeNumber)
+      let changeNumber = getChangeNumber(fruitName: strawberry, changeValue: sender.value)
+      strawberryNumberLabel.text = changeNumber.description
+      store.update(fruitName: .strawberry, number: changeNumber)
     case 1:
-      guard let bananaString = banana else { return }
-      guard let bananaNumber = Int(bananaString) else { return }
-      let bananaChangeNumber = bananaNumber + Int(sender.value)
-      bananaNumberLabel.text = bananaChangeNumber.description
-      store.update(fruitName: .banana, number: bananaChangeNumber)
+      let changeNumber = getChangeNumber(fruitName: banana, changeValue: sender.value)
+      bananaNumberLabel.text = changeNumber.description
+      store.update(fruitName: .banana, number: changeNumber)
     case 2:
-      guard let pineappleString = pineapple else { return }
-      guard let pineappleNumber = Int(pineappleString) else { return }
-      let pineappleChangeNumber = pineappleNumber + Int(sender.value)
-      pineappleNumberLabel.text = pineappleChangeNumber.description
-      store.update(fruitName: .pineapple, number: pineappleChangeNumber)
+      let changeNumber = getChangeNumber(fruitName: pineapple, changeValue: sender.value)
+      pineappleNumberLabel.text = changeNumber.description
+      store.update(fruitName: .pineapple, number: changeNumber)
     case 3:
-      guard let kiwiString = kiwi else { return }
-      guard let kiwiNumber = Int(kiwiString) else { return }
-      let kiwiChangeNumber = kiwiNumber + Int(sender.value)
-      kiwiNumberLabel.text = kiwiChangeNumber.description
-      store.update(fruitName: .kiwi, number: kiwiChangeNumber)
+      let changeNumber = getChangeNumber(fruitName: kiwi, changeValue: sender.value)
+      kiwiNumberLabel.text = changeNumber.description
+      store.update(fruitName: .kiwi, number: changeNumber)
     case 4:
-      guard let mangoString = mango else { return }
-      guard let mangoNumber = Int(mangoString) else { return }
-      let mangoChangeNumber = mangoNumber + Int(sender.value)
-      mangoNumberLabel.text = mangoChangeNumber.description
-      store.update(fruitName: .mango, number: mangoChangeNumber)
+      let changeNumber = getChangeNumber(fruitName: mango, changeValue: sender.value)
+      mangoNumberLabel.text = changeNumber.description
+      store.update(fruitName: .mango, number: changeNumber)
     default:
       return
     }
   }
   
-  func setNumberLabel() {
-    strawberryNumberLabel.text = strawberry
-    bananaNumberLabel.text = banana
-    pineappleNumberLabel.text = pineapple
-    kiwiNumberLabel.text = kiwi
-    mangoNumberLabel.text = mango
+  func getChangeNumber(fruitName: String?, changeValue: Double) -> Int {
+    guard let fruitString = fruitName else { return 0 }
+    guard let fruitNumber = Int(fruitString) else { return 0 }
+    return fruitNumber + Int(changeValue)
   }
   
   func setMinimumValue() {

--- a/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
@@ -13,7 +13,7 @@ final class EditStoreViewController: UIViewController {
   
   private let store = FruitStore.shared
   
-  @IBOutlet var numberLabelCollection: [UILabel]!
+  @IBOutlet private var numberLabelCollection: [UILabel]!
   
   @IBOutlet weak private var strawberryNumberLabel: UILabel!
   @IBOutlet weak private var bananaNumberLabel: UILabel!

--- a/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
@@ -63,31 +63,27 @@ final class EditStoreViewController: UIViewController {
   @IBAction private func stepperButtonTapped(_ sender: UIStepper) {
     switch sender.tag {
     case 0:
-      let changeNumber = getChangeNumber(fruitNumber: strawberryNumber, changeValue: sender.value)
+      let changeNumber = strawberryNumber + Int(sender.value)
       strawberryNumberLabel.text = changeNumber.description
       store.update(fruitName: .strawberry, number: changeNumber)
     case 1:
-      let changeNumber = getChangeNumber(fruitNumber: bananaNumber, changeValue: sender.value)
+      let changeNumber = bananaNumber + Int(sender.value)
       bananaNumberLabel.text = changeNumber.description
       store.update(fruitName: .banana, number: changeNumber)
     case 2:
-      let changeNumber = getChangeNumber(fruitNumber: pineappleNumber, changeValue: sender.value)
+      let changeNumber = pineappleNumber + Int(sender.value)
       pineappleNumberLabel.text = changeNumber.description
       store.update(fruitName: .pineapple, number: changeNumber)
     case 3:
-      let changeNumber = getChangeNumber(fruitNumber: kiwiNumber, changeValue: sender.value)
+      let changeNumber = kiwiNumber + Int(sender.value)
       kiwiNumberLabel.text = changeNumber.description
       store.update(fruitName: .kiwi, number: changeNumber)
     case 4:
-      let changeNumber = getChangeNumber(fruitNumber: mangoNumber, changeValue: sender.value)
+      let changeNumber = mangoNumber + Int(sender.value)
       mangoNumberLabel.text = changeNumber.description
       store.update(fruitName: .mango, number: changeNumber)
     default:
       return
     }
-  }
-  
-  private func getChangeNumber(fruitNumber: Int, changeValue: Double) -> Int {
-    return fruitNumber + Int(changeValue)
   }
 }

--- a/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
@@ -11,13 +11,13 @@ final class EditStoreViewController: UIViewController {
   
   weak var delegate: DismissEditStoreViewDelegate?
   
-  var strawberryValue: String?
-  var bananaValue: String?
-  var pineappleValue: String?
-  var kiwiValue: String?
-  var mangoValue: String?
-  
   private let store = FruitStore.shared
+  
+  lazy private var strawberryNumber = store.getNum(fruitName: .strawberry)
+  lazy private var bananaNumber = store.getNum(fruitName: .banana)
+  lazy private var pineappleNumber = store.getNum(fruitName: .pineapple)
+  lazy private var kiwiNumber = store.getNum(fruitName: .kiwi)
+  lazy private var mangoNumber = store.getNum(fruitName: .mango)
   
   @IBOutlet weak private var strawberryNumberLabel: UILabel!
   @IBOutlet weak private var bananaNumberLabel: UILabel!
@@ -38,11 +38,11 @@ final class EditStoreViewController: UIViewController {
   }
   
   private func setNumberLabel() {
-    strawberryNumberLabel.text = strawberryValue
-    bananaNumberLabel.text = bananaValue
-    pineappleNumberLabel.text = pineappleValue
-    kiwiNumberLabel.text = kiwiValue
-    mangoNumberLabel.text = mangoValue
+    strawberryNumberLabel.text = strawberryNumber.description
+    bananaNumberLabel.text = bananaNumber.description
+    pineappleNumberLabel.text = pineappleNumber.description
+    kiwiNumberLabel.text = kiwiNumber.description
+    mangoNumberLabel.text = mangoNumber.description
   }
   
   private func setMinimumValue() {
@@ -63,23 +63,23 @@ final class EditStoreViewController: UIViewController {
   @IBAction private func stepperButtonTapped(_ sender: UIStepper) {
     switch sender.tag {
     case 0:
-      let changeNumber = getChangeNumber(fruitNumber: strawberryValue, changeValue: sender.value)
+      let changeNumber = getChangeNumber(fruitNumber: strawberryNumber, changeValue: sender.value)
       strawberryNumberLabel.text = changeNumber.description
       store.update(fruitName: .strawberry, number: changeNumber)
     case 1:
-      let changeNumber = getChangeNumber(fruitNumber: bananaValue, changeValue: sender.value)
+      let changeNumber = getChangeNumber(fruitNumber: bananaNumber, changeValue: sender.value)
       bananaNumberLabel.text = changeNumber.description
       store.update(fruitName: .banana, number: changeNumber)
     case 2:
-      let changeNumber = getChangeNumber(fruitNumber: pineappleValue, changeValue: sender.value)
+      let changeNumber = getChangeNumber(fruitNumber: pineappleNumber, changeValue: sender.value)
       pineappleNumberLabel.text = changeNumber.description
       store.update(fruitName: .pineapple, number: changeNumber)
     case 3:
-      let changeNumber = getChangeNumber(fruitNumber: kiwiValue, changeValue: sender.value)
+      let changeNumber = getChangeNumber(fruitNumber: kiwiNumber, changeValue: sender.value)
       kiwiNumberLabel.text = changeNumber.description
       store.update(fruitName: .kiwi, number: changeNumber)
     case 4:
-      let changeNumber = getChangeNumber(fruitNumber: mangoValue, changeValue: sender.value)
+      let changeNumber = getChangeNumber(fruitNumber: mangoNumber, changeValue: sender.value)
       mangoNumberLabel.text = changeNumber.description
       store.update(fruitName: .mango, number: changeNumber)
     default:
@@ -87,9 +87,7 @@ final class EditStoreViewController: UIViewController {
     }
   }
   
-  private func getChangeNumber(fruitNumber: String?, changeValue: Double) -> Int {
-    guard let stringFruitValue = fruitNumber else { return 0 }
-    guard let intFruitValue = Int(stringFruitValue) else { return 0 }
-    return intFruitValue + Int(changeValue)
+  private func getChangeNumber(fruitNumber: Int, changeValue: Double) -> Int {
+    return fruitNumber + Int(changeValue)
   }
 }

--- a/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
@@ -10,13 +10,14 @@ import UIKit
 final class EditStoreViewController: UIViewController {
   
   var delegate: DismissEditStoreViewDelegate?
-  private let store = FruitStore.shared
   
   var strawberryValue: String?
   var bananaValue: String?
   var pineappleValue: String?
   var kiwiValue: String?
   var mangoValue: String?
+  
+  private let store = FruitStore.shared
   
   @IBOutlet weak private var strawberryNumberLabel: UILabel!
   @IBOutlet weak private var bananaNumberLabel: UILabel!

--- a/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStoreViewController.swift
@@ -21,9 +21,16 @@ class EditStoreViewController: UIViewController {
   @IBOutlet weak var kiwiNumberLabel: UILabel!
   @IBOutlet weak var mangoNumberLabel: UILabel!
   
+  @IBOutlet weak var strawberryStepper: UIStepper!
+  @IBOutlet weak var bananaStepper: UIStepper!
+  @IBOutlet weak var pineappleStepper: UIStepper!
+  @IBOutlet weak var kiwiStepper: UIStepper!
+  @IBOutlet weak var mangoStepper: UIStepper!
+  
   override func viewDidLoad() {
     super.viewDidLoad()
     setNumberLabel()
+    setMinimumValue()
   }
   
   @IBAction func dismissButtonTapped(_ sender: UIButton) {
@@ -58,7 +65,6 @@ class EditStoreViewController: UIViewController {
     }
   }
   
-  
   func setNumberLabel() {
     strawberryNumberLabel.text = strawberry
     bananaNumberLabel.text = banana
@@ -66,4 +72,27 @@ class EditStoreViewController: UIViewController {
     kiwiNumberLabel.text = kiwi
     mangoNumberLabel.text = mango
   }
+  
+  func setMinimumValue() {
+    guard let strawberryString = strawberry else { return }
+    guard let strawberryDouble = Double(strawberryString) else { return }
+    strawberryStepper.minimumValue = -strawberryDouble
+    
+    guard let bananaString = banana else { return }
+    guard let bananaDouble = Double(bananaString) else { return }
+    bananaStepper.minimumValue = -bananaDouble
+    
+    guard let pineappleString = pineapple else { return }
+    guard let pineappleDouble = Double(pineappleString) else { return }
+    pineappleStepper.minimumValue = -pineappleDouble
+    
+    guard let kiwiString = kiwi else { return }
+    guard let kiwiDouble = Double(kiwiString) else { return }
+    kiwiStepper.minimumValue = -kiwiDouble
+    
+    guard let mangoString = mango else { return }
+    guard let mangoDouble = Double(mangoString) else { return }
+    mangoStepper.minimumValue = -mangoDouble
+  }
+  
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -6,11 +6,11 @@
 
 import UIKit
 
-protocol UpdateProtocol {
-  func update()
+protocol ViewControllerDelegate {
+  func updateData()
 }
 
-class ViewController: UIViewController, UpdateProtocol {
+class ViewController: UIViewController, ViewControllerDelegate {
   
   let juiceMaker = JuiceMaker()
   
@@ -25,15 +25,7 @@ class ViewController: UIViewController, UpdateProtocol {
     setNumberLabel()
   }
   
-  @IBAction func juiceOrderButtonTapped(_ sender: UIButton) {
-    guard let buttonName = sender.titleLabel?.text else { return }
-    let juiceName = buttonName.split(separator: " ")[0]
-    let message = juiceMaker.createJuice(type: String(juiceName))
-    showAlert(message: message)
-    setNumberLabel()
-  }
-  
-  func update() {
+  func updateData() {
     setNumberLabel()
   }
   
@@ -43,6 +35,14 @@ class ViewController: UIViewController, UpdateProtocol {
     pineappleNumberLabel.text = String(juiceMaker.store.getNum(fruitName: Fruit.pineapple))
     kiwiNumberLabel.text = String(juiceMaker.store.getNum(fruitName: Fruit.kiwi))
     mangoNumberLabel.text = String(juiceMaker.store.getNum(fruitName: Fruit.mango))
+  }
+  
+  @IBAction func juiceOrderButtonTapped(_ sender: UIButton) {
+    guard let buttonName = sender.titleLabel?.text else { return }
+    let juiceName = buttonName.split(separator: " ")[0]
+    let message = juiceMaker.createJuice(type: String(juiceName))
+    showAlert(message: message)
+    setNumberLabel()
   }
   
   func showAlert(message: String) {
@@ -71,11 +71,11 @@ class ViewController: UIViewController, UpdateProtocol {
   }
   
   func sendData(view: EditStoreViewController) {
-    view.strawberry = self.strawberryNumberLabel?.text
-    view.banana = self.bananaNumberLabel?.text
-    view.pineapple = self.pineappleNumberLabel?.text
-    view.kiwi = self.kiwiNumberLabel?.text
-    view.mango = self.mangoNumberLabel?.text
+    view.strawberryValue = self.strawberryNumberLabel?.text
+    view.bananaValue = self.bananaNumberLabel?.text
+    view.pineappleValue = self.pineappleNumberLabel?.text
+    view.kiwiValue = self.kiwiNumberLabel?.text
+    view.mangoValue = self.mangoNumberLabel?.text
     view.delegate = self
   }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -25,6 +25,13 @@ final class ViewController: UIViewController, DismissEditStoreViewDelegate {
     setNumberLabel()
   }
   
+  override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+    if segue.destination is EditStoreViewController {
+      guard let editStoreView = segue.destination as? EditStoreViewController else { return }
+      sendData(view: editStoreView)
+    }
+  }
+  
   func updateData() {
     setNumberLabel()
   }
@@ -61,13 +68,6 @@ final class ViewController: UIViewController, DismissEditStoreViewDelegate {
     
     alert.addAction(UIAlertAction(title: outOfStock ? "아니오" : "확인", style: UIAlertAction.Style.cancel, handler: nil))
     self.present(alert, animated: true, completion: nil)
-  }
-  
-  override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-    if segue.destination is EditStoreViewController {
-      guard let editStoreView = segue.destination as? EditStoreViewController else { return }
-      sendData(view: editStoreView)
-    }
   }
   
   private func sendData(view: EditStoreViewController) {

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -11,9 +11,6 @@ protocol UpdateProtocol {
 }
 
 class ViewController: UIViewController, UpdateProtocol {
-  func update() {
-    setNumberLabel()
-  }
   
   let juiceMaker = JuiceMaker()
   
@@ -28,16 +25,15 @@ class ViewController: UIViewController, UpdateProtocol {
     setNumberLabel()
   }
   
-  override func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
-    setNumberLabel()
-  }
-  
   @IBAction func juiceOrderButtonTapped(_ sender: UIButton) {
     guard let buttonName = sender.titleLabel?.text else { return }
     let juiceName = buttonName.split(separator: " ")[0]
     let message = juiceMaker.createJuice(type: String(juiceName))
     showAlert(message: message)
+    setNumberLabel()
+  }
+  
+  func update() {
     setNumberLabel()
   }
   
@@ -54,19 +50,11 @@ class ViewController: UIViewController, UpdateProtocol {
     let outOfStock = (message == "재료가 모자라요. 재고를 수정할까요?")
     
     if outOfStock {
-      alert.addAction(UIAlertAction(title: "예", style: UIAlertAction.Style.default, handler: { _ in
+      alert.addAction(UIAlertAction(title: "예", style: UIAlertAction.Style.default, handler: { [self] _ in
         guard let editStoreView = self.storyboard?.instantiateViewController(identifier: "editStoreView") as? EditStoreViewController else { return }
         editStoreView.modalTransitionStyle = .coverVertical
         editStoreView.modalPresentationStyle = .automatic
-        
-        editStoreView.strawberry = self.strawberryNumberLabel?.text
-        editStoreView.banana = self.bananaNumberLabel?.text
-        editStoreView.pineapple = self.pineappleNumberLabel?.text
-        editStoreView.kiwi = self.kiwiNumberLabel?.text
-        editStoreView.mango = self.mangoNumberLabel?.text
-        
-        editStoreView.delegate = self
-        
+        sendData(view: editStoreView)
         self.present(editStoreView, animated: true, completion: nil)
       }))
     }
@@ -77,14 +65,17 @@ class ViewController: UIViewController, UpdateProtocol {
   
   override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
     if segue.destination is EditStoreViewController {
-      let editStoreView = segue.destination as? EditStoreViewController
-      editStoreView?.strawberry = self.strawberryNumberLabel?.text
-      editStoreView?.banana = self.bananaNumberLabel?.text
-      editStoreView?.pineapple = self.pineappleNumberLabel?.text
-      editStoreView?.kiwi = self.kiwiNumberLabel?.text
-      editStoreView?.mango = self.mangoNumberLabel?.text
-      
-      editStoreView?.delegate = self
+      guard let editStoreView = segue.destination as? EditStoreViewController else { return }
+      sendData(view: editStoreView)
     }
+  }
+  
+  func sendData(view: EditStoreViewController) {
+    view.strawberry = self.strawberryNumberLabel?.text
+    view.banana = self.bananaNumberLabel?.text
+    view.pineapple = self.pineappleNumberLabel?.text
+    view.kiwi = self.kiwiNumberLabel?.text
+    view.mango = self.mangoNumberLabel?.text
+    view.delegate = self
   }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -45,13 +45,31 @@ class ViewController: UIViewController {
       alert.addAction(UIAlertAction(title: "확인", style: UIAlertAction.Style.default, handler: nil))
     } else if type == .twoButton {
       alert.addAction(UIAlertAction(title: "예", style: UIAlertAction.Style.default, handler: { _ in
-        guard let editStoreView = self.storyboard?.instantiateViewController(identifier: "editStoreView") else { return }
+        guard let editStoreView = self.storyboard?.instantiateViewController(identifier: "editStoreView") as? EditStoreViewController else { return }
         editStoreView.modalTransitionStyle = .coverVertical
         editStoreView.modalPresentationStyle = .automatic
+        
+        editStoreView.strawberry = self.strawberryNumberLabel?.text
+        editStoreView.banana = self.bananaNumberLabel?.text
+        editStoreView.pineapple = self.pineappleNumberLabel?.text
+        editStoreView.kiwi = self.kiwiNumberLabel?.text
+        editStoreView.mango = self.mangoNumberLabel?.text
+        
         self.present(editStoreView, animated: true, completion: nil)
       }))
       alert.addAction(UIAlertAction(title: "아니오", style: UIAlertAction.Style.cancel, handler: nil))
     }
     self.present(alert, animated: true, completion: nil)
   }
+  
+  override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+      if segue.destination is EditStoreViewController {
+        let editStoreView = segue.destination as? EditStoreViewController
+        editStoreView?.strawberry = self.strawberryNumberLabel?.text
+        editStoreView?.banana = self.bananaNumberLabel?.text
+        editStoreView?.pineapple = self.pineappleNumberLabel?.text
+        editStoreView?.kiwi = self.kiwiNumberLabel?.text
+        editStoreView?.mango = self.mangoNumberLabel?.text
+      }
+    }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -71,11 +71,6 @@ final class ViewController: UIViewController, DismissEditStoreViewDelegate {
   }
   
   private func sendData(view: EditStoreViewController) {
-    view.strawberryValue = self.strawberryNumberLabel?.text
-    view.bananaValue = self.bananaNumberLabel?.text
-    view.pineappleValue = self.pineappleNumberLabel?.text
-    view.kiwiValue = self.kiwiNumberLabel?.text
-    view.mangoValue = self.mangoNumberLabel?.text
     view.delegate = self
   }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-protocol DismissEditStoreViewDelegate {
+protocol DismissEditStoreViewDelegate: AnyObject {
   func updateData()
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -10,15 +10,15 @@ protocol ViewControllerDelegate {
   func updateData()
 }
 
-class ViewController: UIViewController, ViewControllerDelegate {
+final class ViewController: UIViewController, ViewControllerDelegate {
   
-  let juiceMaker = JuiceMaker()
+  private let juiceMaker = JuiceMaker()
   
-  @IBOutlet weak var strawberryNumberLabel: UILabel!
-  @IBOutlet weak var bananaNumberLabel: UILabel!
-  @IBOutlet weak var pineappleNumberLabel: UILabel!
-  @IBOutlet weak var kiwiNumberLabel: UILabel!
-  @IBOutlet weak var mangoNumberLabel: UILabel!
+  @IBOutlet weak private var strawberryNumberLabel: UILabel!
+  @IBOutlet weak private var bananaNumberLabel: UILabel!
+  @IBOutlet weak private var pineappleNumberLabel: UILabel!
+  @IBOutlet weak private var kiwiNumberLabel: UILabel!
+  @IBOutlet weak private var mangoNumberLabel: UILabel!
   
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -37,7 +37,7 @@ class ViewController: UIViewController, ViewControllerDelegate {
     mangoNumberLabel.text = String(juiceMaker.store.getNum(fruitName: Fruit.mango))
   }
   
-  @IBAction func juiceOrderButtonTapped(_ sender: UIButton) {
+  @IBAction private func juiceOrderButtonTapped(_ sender: UIButton) {
     guard let buttonName = sender.titleLabel?.text else { return }
     let juiceName = buttonName.split(separator: " ")[0]
     let message = juiceMaker.createJuice(type: String(juiceName))
@@ -45,7 +45,7 @@ class ViewController: UIViewController, ViewControllerDelegate {
     setNumberLabel()
   }
   
-  func showAlert(message: String) {
+  private func showAlert(message: String) {
     let alert = UIAlertController(title: "", message: message, preferredStyle: UIAlertController.Style.alert)
     let outOfStock = (message == "재료가 모자라요. 재고를 수정할까요?")
     
@@ -70,7 +70,7 @@ class ViewController: UIViewController, ViewControllerDelegate {
     }
   }
   
-  func sendData(view: EditStoreViewController) {
+  private func sendData(view: EditStoreViewController) {
     view.strawberryValue = self.strawberryNumberLabel?.text
     view.bananaValue = self.bananaNumberLabel?.text
     view.pineappleValue = self.pineappleNumberLabel?.text

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -6,7 +6,14 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+protocol UpdateProtocol {
+  func update()
+}
+
+class ViewController: UIViewController, UpdateProtocol {
+  func update() {
+    setNumberLabel()
+  }
   
   let juiceMaker = JuiceMaker()
   
@@ -18,6 +25,11 @@ class ViewController: UIViewController {
   
   override func viewDidLoad() {
     super.viewDidLoad()
+    setNumberLabel()
+  }
+  
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
     setNumberLabel()
   }
   
@@ -53,6 +65,8 @@ class ViewController: UIViewController {
         editStoreView.kiwi = self.kiwiNumberLabel?.text
         editStoreView.mango = self.mangoNumberLabel?.text
         
+        editStoreView.delegate = self
+        
         self.present(editStoreView, animated: true, completion: nil)
       }))
     }
@@ -62,13 +76,15 @@ class ViewController: UIViewController {
   }
   
   override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-      if segue.destination is EditStoreViewController {
-        let editStoreView = segue.destination as? EditStoreViewController
-        editStoreView?.strawberry = self.strawberryNumberLabel?.text
-        editStoreView?.banana = self.bananaNumberLabel?.text
-        editStoreView?.pineapple = self.pineappleNumberLabel?.text
-        editStoreView?.kiwi = self.kiwiNumberLabel?.text
-        editStoreView?.mango = self.mangoNumberLabel?.text
-      }
+    if segue.destination is EditStoreViewController {
+      let editStoreView = segue.destination as? EditStoreViewController
+      editStoreView?.strawberry = self.strawberryNumberLabel?.text
+      editStoreView?.banana = self.bananaNumberLabel?.text
+      editStoreView?.pineapple = self.pineappleNumberLabel?.text
+      editStoreView?.kiwi = self.kiwiNumberLabel?.text
+      editStoreView?.mango = self.mangoNumberLabel?.text
+      
+      editStoreView?.delegate = self
     }
+  }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -25,11 +25,10 @@ final class ViewController: UIViewController, DismissEditStoreViewDelegate {
     setNumberLabel()
   }
   
-  override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-    if segue.destination is EditStoreViewController {
-      guard let editStoreView = segue.destination as? EditStoreViewController else { return }
-      sendData(view: editStoreView)
-    }
+  @IBAction func editButtonTapped(_ sender: UIBarButtonItem) {
+    guard let editStoreView = storyboard?.instantiateViewController(identifier: "EditStoreView") as? EditStoreViewController else { return }
+    editStoreView.delegate = self
+    self.present(editStoreView, animated: true)
   }
   
   func updateData() {
@@ -58,19 +57,15 @@ final class ViewController: UIViewController, DismissEditStoreViewDelegate {
     
     if outOfStock {
       alert.addAction(UIAlertAction(title: "예", style: UIAlertAction.Style.default, handler: { [self] _ in
-        guard let editStoreView = self.storyboard?.instantiateViewController(identifier: "editStoreView") as? EditStoreViewController else { return }
+        guard let editStoreView = self.storyboard?.instantiateViewController(identifier: "EditStoreView") as? EditStoreViewController else { return }
         editStoreView.modalTransitionStyle = .coverVertical
         editStoreView.modalPresentationStyle = .automatic
-        sendData(view: editStoreView)
+        editStoreView.delegate = self
         self.present(editStoreView, animated: true, completion: nil)
       }))
     }
     
     alert.addAction(UIAlertAction(title: outOfStock ? "아니오" : "확인", style: UIAlertAction.Style.cancel, handler: nil))
     self.present(alert, animated: true, completion: nil)
-  }
-  
-  private func sendData(view: EditStoreViewController) {
-    view.delegate = self
   }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -6,11 +6,11 @@
 
 import UIKit
 
-protocol ViewControllerDelegate {
+protocol DismissEditStoreViewDelegate {
   func updateData()
 }
 
-final class ViewController: UIViewController, ViewControllerDelegate {
+final class ViewController: UIViewController, DismissEditStoreViewDelegate {
   
   private let juiceMaker = JuiceMaker()
   

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -19,10 +19,8 @@ class FruitStore {
     }
   }
   
-  func add(fruitName: Fruit, number: Int) {
-    let currentNumber = getNum(fruitName: fruitName)
-    let result = currentNumber + number
-    inventory.updateValue(result, forKey: fruitName)
+  func update(fruitName: Fruit, number: Int) {
+    inventory.updateValue(number, forKey: fruitName)
   }
   
   func subtract(fruitName: Fruit, number: Int) {

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -12,7 +12,7 @@ struct JuiceMaker {
   let store = FruitStore.shared
   
   enum Juice: String {
-    case strawberry = "딸기 쥬스"
+    case strawberry = "딸기쥬스"
     case banana = "바나나쥬스"
     case kiwi = "키위쥬스"
     case pineapple = "파인애플쥬스"

--- a/JuiceMaker/JuiceMaker/Model/Type.swift
+++ b/JuiceMaker/JuiceMaker/Model/Type.swift
@@ -7,10 +7,10 @@
 
 import Foundation
 
-enum Fruit: String {
+enum Fruit: Int {
   case strawberry
-  case pineapple
   case banana
+  case pineapple
   case kiwi
   case mango
 }

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -275,7 +275,7 @@
         <!--재고 추가-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
-                <viewController storyboardIdentifier="editStoreView" id="Yu1-lM-nqp" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="editStoreView" id="Yu1-lM-nqp" customClass="EditStoreViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -421,7 +421,11 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="재고 추가" id="rO2-xT-2dN">
-                        <barButtonItem key="rightBarButtonItem" title="닫기" id="zYB-4i-afO"/>
+                        <barButtonItem key="rightBarButtonItem" title="닫기" id="zYB-4i-afO">
+                            <connections>
+                                <action selector="dismissButtonTapped:" destination="Yu1-lM-nqp" id="wAs-cN-Aag"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -468,10 +468,15 @@
                     <navigationItem key="navigationItem" id="rO2-xT-2dN"/>
                     <connections>
                         <outlet property="bananaNumberLabel" destination="gKu-86-RhI" id="mBo-IH-1ae"/>
+                        <outlet property="bananaStepper" destination="O5s-2N-3iP" id="9W8-Ln-ecP"/>
                         <outlet property="kiwiNumberLabel" destination="ZDv-1m-HBY" id="vH7-GE-8x3"/>
+                        <outlet property="kiwiStepper" destination="klA-59-Nu4" id="JsO-1n-G5D"/>
                         <outlet property="mangoNumberLabel" destination="YJI-ER-LJR" id="iFU-7x-5tD"/>
+                        <outlet property="mangoStepper" destination="xbn-6P-grO" id="7sw-84-sK1"/>
                         <outlet property="pineappleNumberLabel" destination="MpT-VW-hCb" id="1rs-61-oEe"/>
+                        <outlet property="pineappleStepper" destination="Rcr-xr-eqz" id="Qju-AW-QIf"/>
                         <outlet property="strawberryNumberLabel" destination="0yV-kn-zaT" id="eUz-qq-p6I"/>
+                        <outlet property="strawberryStepper" destination="ZQk-f4-zrz" id="Zac-HU-SSt"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -280,14 +280,14 @@
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="7MH-0F-wAJ">
-                                <rect key="frame" x="107" y="114" width="630" height="162"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="7MH-0F-wAJ">
+                                <rect key="frame" x="147" y="114" width="550" height="162"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="n1q-5u-u1i">
                                         <rect key="frame" x="0.0" y="0.0" width="94" height="162"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                                <rect key="frame" x="9.6666666666666714" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="9.6666666666666572" y="0.0" width="75" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -312,10 +312,10 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="PVe-GQ-wel">
-                                        <rect key="frame" x="134" y="0.0" width="94" height="162"/>
+                                        <rect key="frame" x="114" y="0.0" width="94" height="162"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                                <rect key="frame" x="9.6666666666666572" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="9.6666666666666856" y="0.0" width="75" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -340,7 +340,7 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Xwa-bq-FEq">
-                                        <rect key="frame" x="268" y="0.0" width="94" height="162"/>
+                                        <rect key="frame" x="228" y="0.0" width="94" height="162"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
                                                 <rect key="frame" x="9.6666666666666856" y="0.0" width="75" height="83.666666666666671"/>
@@ -368,10 +368,10 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="0qG-6S-hp3">
-                                        <rect key="frame" x="402" y="0.0" width="94" height="162"/>
+                                        <rect key="frame" x="342" y="0.0" width="94" height="162"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                                <rect key="frame" x="9.6666666666666288" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="9.6666666666666856" y="0.0" width="75" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -396,7 +396,7 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="HpM-Pp-0un">
-                                        <rect key="frame" x="536" y="0.0" width="94" height="162"/>
+                                        <rect key="frame" x="456" y="0.0" width="94" height="162"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
                                                 <rect key="frame" x="9.6666666666666288" y="0.0" width="75" height="83.666666666666671"/>
@@ -461,8 +461,10 @@
                             <constraint firstItem="7MH-0F-wAJ" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="3b9-4B-XnS"/>
                             <constraint firstItem="7MH-0F-wAJ" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="4ro-xW-Qnb"/>
                             <constraint firstAttribute="trailing" secondItem="uU8-lj-E1b" secondAttribute="trailing" id="Cqo-xF-SwP"/>
+                            <constraint firstItem="7MH-0F-wAJ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="gcO-Xb-kNs" secondAttribute="leading" constant="10" id="LOm-dW-dx6"/>
                             <constraint firstItem="uU8-lj-E1b" firstAttribute="top" secondItem="tKV-4l-Vtc" secondAttribute="top" id="ffW-OO-GSc"/>
                             <constraint firstItem="uU8-lj-E1b" firstAttribute="leading" secondItem="tKV-4l-Vtc" secondAttribute="leading" id="mbg-wA-cm4"/>
+                            <constraint firstItem="gcO-Xb-kNs" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="7MH-0F-wAJ" secondAttribute="trailing" constant="10" id="rmn-fL-ka4"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="rO2-xT-2dN"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -301,6 +301,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                                 <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="stepperButtonTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="npQ-rc-P6G"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -324,8 +327,11 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
+                                            <stepper opaque="NO" tag="1" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
                                                 <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="stepperButtonTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="FHf-Q6-gbi"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -349,8 +355,11 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
+                                            <stepper opaque="NO" tag="2" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
                                                 <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="stepperButtonTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="rgZ-1H-kyh"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -374,8 +383,11 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
+                                            <stepper opaque="NO" tag="3" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
                                                 <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="stepperButtonTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="uEQ-TL-atQ"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -399,8 +411,11 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
+                                            <stepper opaque="NO" tag="4" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
                                                 <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="stepperButtonTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="six-ak-FHd"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -238,7 +238,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <segue destination="WwV-Td-3Bn" kind="presentation" id="ZgC-Do-Sqr"/>
+                                <segue destination="Yu1-lM-nqp" kind="presentation" id="jZl-Nj-h4Q"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -272,7 +272,7 @@
             </objects>
             <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
         </scene>
-        <!--재고 추가-->
+        <!--Edit Store View Controller-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
                 <viewController storyboardIdentifier="editStoreView" id="Yu1-lM-nqp" customClass="EditStoreViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
@@ -412,25 +412,49 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uU8-lj-E1b">
+                                <rect key="frame" x="0.0" y="0.0" width="844" height="42"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="재고 추가" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="G3o-BH-DeK">
+                                        <rect key="frame" x="388.66666666666669" y="10.333333333333334" width="67" height="21.666666666666664"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eI1-aa-MhL">
+                                        <rect key="frame" x="765.33333333333337" y="4" width="53.666666666666629" height="34.333333333333336"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="닫기"/>
+                                        <connections>
+                                            <action selector="dismissButtonTapped:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="2pd-3V-CjF"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                <constraints>
+                                    <constraint firstItem="G3o-BH-DeK" firstAttribute="centerY" secondItem="uU8-lj-E1b" secondAttribute="centerY" id="5mP-5a-BdF"/>
+                                    <constraint firstAttribute="height" constant="42" id="6or-3U-doG"/>
+                                    <constraint firstAttribute="trailing" secondItem="eI1-aa-MhL" secondAttribute="trailing" constant="25" id="Poc-RD-sHA"/>
+                                    <constraint firstItem="G3o-BH-DeK" firstAttribute="centerX" secondItem="uU8-lj-E1b" secondAttribute="centerX" id="QSu-tQ-VOE"/>
+                                    <constraint firstItem="eI1-aa-MhL" firstAttribute="centerY" secondItem="uU8-lj-E1b" secondAttribute="centerY" id="pPg-6p-wCM"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="7MH-0F-wAJ" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="3b9-4B-XnS"/>
                             <constraint firstItem="7MH-0F-wAJ" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="4ro-xW-Qnb"/>
+                            <constraint firstAttribute="trailing" secondItem="uU8-lj-E1b" secondAttribute="trailing" id="Cqo-xF-SwP"/>
+                            <constraint firstItem="uU8-lj-E1b" firstAttribute="top" secondItem="tKV-4l-Vtc" secondAttribute="top" id="ffW-OO-GSc"/>
+                            <constraint firstItem="uU8-lj-E1b" firstAttribute="leading" secondItem="tKV-4l-Vtc" secondAttribute="leading" id="mbg-wA-cm4"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" title="재고 추가" id="rO2-xT-2dN">
-                        <barButtonItem key="rightBarButtonItem" title="닫기" id="zYB-4i-afO">
-                            <connections>
-                                <action selector="dismissButtonTapped:" destination="Yu1-lM-nqp" id="wAs-cN-Aag"/>
-                            </connections>
-                        </barButtonItem>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" id="rO2-xT-2dN"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1637" y="901"/>
+            <point key="canvasLocation" x="1636.4928909952605" y="900"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="cAf-jL-tPK">
@@ -453,6 +477,9 @@
             <point key="canvasLocation" x="1637" y="21"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="jZl-Nj-h4Q"/>
+    </inferredMetricsTieBreakers>
     <resources>
         <namedColor name="AccentColor">
             <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -238,7 +238,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <segue destination="Yu1-lM-nqp" kind="presentation" id="jZl-Nj-h4Q"/>
+                                <action selector="editButtonTapped:" destination="BYZ-38-t0r" id="9nk-LC-pxS"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -275,7 +275,7 @@
         <!--Edit Store View Controller-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
-                <viewController storyboardIdentifier="editStoreView" id="Yu1-lM-nqp" customClass="EditStoreViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="EditStoreView" id="Yu1-lM-nqp" customClass="EditStoreViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -511,9 +511,6 @@
             <point key="canvasLocation" x="1637" y="21"/>
         </scene>
     </scenes>
-    <inferredMetricsTieBreakers>
-        <segue reference="wH1-3A-cBm"/>
-    </inferredMetricsTieBreakers>
     <resources>
         <namedColor name="AccentColor">
             <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -320,7 +320,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
                                                 <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -348,7 +348,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
                                                 <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -376,7 +376,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="3" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
                                                 <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -404,7 +404,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="4" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
                                                 <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -479,6 +479,11 @@
                         <outlet property="pineappleStepper" destination="Rcr-xr-eqz" id="Qju-AW-QIf"/>
                         <outlet property="strawberryNumberLabel" destination="0yV-kn-zaT" id="eUz-qq-p6I"/>
                         <outlet property="strawberryStepper" destination="ZQk-f4-zrz" id="Zac-HU-SSt"/>
+                        <outletCollection property="numberLabelCollection" destination="YJI-ER-LJR" collectionClass="NSMutableArray" id="flP-Y6-o9L"/>
+                        <outletCollection property="numberLabelCollection" destination="ZDv-1m-HBY" collectionClass="NSMutableArray" id="4Ev-ID-tUB"/>
+                        <outletCollection property="numberLabelCollection" destination="MpT-VW-hCb" collectionClass="NSMutableArray" id="7dk-bS-Zj0"/>
+                        <outletCollection property="numberLabelCollection" destination="gKu-86-RhI" collectionClass="NSMutableArray" id="4Fu-yg-3EF"/>
+                        <outletCollection property="numberLabelCollection" destination="0yV-kn-zaT" collectionClass="NSMutableArray" id="fbP-24-dfP"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -451,6 +451,13 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="rO2-xT-2dN"/>
+                    <connections>
+                        <outlet property="bananaNumberLabel" destination="gKu-86-RhI" id="mBo-IH-1ae"/>
+                        <outlet property="kiwiNumberLabel" destination="ZDv-1m-HBY" id="vH7-GE-8x3"/>
+                        <outlet property="mangoNumberLabel" destination="YJI-ER-LJR" id="iFU-7x-5tD"/>
+                        <outlet property="pineappleNumberLabel" destination="MpT-VW-hCb" id="1rs-61-oEe"/>
+                        <outlet property="strawberryNumberLabel" destination="0yV-kn-zaT" id="eUz-qq-p6I"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
@@ -478,7 +485,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="jZl-Nj-h4Q"/>
+        <segue reference="wH1-3A-cBm"/>
     </inferredMetricsTieBreakers>
     <resources>
         <namedColor name="AccentColor">

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -238,7 +238,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <segue destination="Yu1-lM-nqp" kind="presentation" id="URg-3w-vuf"/>
+                                <segue destination="WwV-Td-3Bn" kind="presentation" id="ZgC-Do-Sqr"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -272,7 +272,7 @@
             </objects>
             <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
         </scene>
-        <!--View Controller-->
+        <!--재고 추가-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
                 <viewController storyboardIdentifier="editStoreView" id="Yu1-lM-nqp" sceneMemberID="viewController">
@@ -280,106 +280,149 @@
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                <rect key="frame" x="590" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                <rect key="frame" x="622" y="156" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                <rect key="frame" x="580" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                <rect key="frame" x="429" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                <rect key="frame" x="461" y="156" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                <rect key="frame" x="410" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                <rect key="frame" x="271" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                <rect key="frame" x="303" y="155" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                <rect key="frame" x="261" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                <rect key="frame" x="165" y="73" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                <rect key="frame" x="154" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                <rect key="frame" x="98" y="161" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                <rect key="frame" x="60" y="73" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                <rect key="frame" x="196" y="158" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                <rect key="frame" x="50" y="192" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stepper>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="7MH-0F-wAJ">
+                                <rect key="frame" x="107" y="114" width="630" height="162"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="n1q-5u-u1i">
+                                        <rect key="frame" x="0.0" y="0.0" width="94" height="162"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
+                                                <rect key="frame" x="9.6666666666666714" y="0.0" width="75" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
+                                                <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
+                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                            </stepper>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="0yV-kn-zaT" firstAttribute="leading" secondItem="n1q-5u-u1i" secondAttribute="leading" id="5tq-Eb-70C"/>
+                                            <constraint firstAttribute="trailing" secondItem="0yV-kn-zaT" secondAttribute="trailing" id="AYm-Et-EM7"/>
+                                        </constraints>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="PVe-GQ-wel">
+                                        <rect key="frame" x="134" y="0.0" width="94" height="162"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
+                                                <rect key="frame" x="9.6666666666666572" y="0.0" width="75" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
+                                                <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
+                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                            </stepper>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="gKu-86-RhI" firstAttribute="leading" secondItem="PVe-GQ-wel" secondAttribute="leading" id="GYT-BC-GS3"/>
+                                            <constraint firstAttribute="trailing" secondItem="gKu-86-RhI" secondAttribute="trailing" id="NRa-YD-6Na"/>
+                                        </constraints>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Xwa-bq-FEq">
+                                        <rect key="frame" x="268" y="0.0" width="94" height="162"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
+                                                <rect key="frame" x="9.6666666666666856" y="0.0" width="75" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
+                                                <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
+                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                            </stepper>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="MpT-VW-hCb" firstAttribute="leading" secondItem="Xwa-bq-FEq" secondAttribute="leading" id="W4u-2U-wtm"/>
+                                            <constraint firstAttribute="trailing" secondItem="MpT-VW-hCb" secondAttribute="trailing" id="odJ-Do-vFB"/>
+                                        </constraints>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="0qG-6S-hp3">
+                                        <rect key="frame" x="402" y="0.0" width="94" height="162"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
+                                                <rect key="frame" x="9.6666666666666288" y="0.0" width="75" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
+                                                <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
+                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                            </stepper>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="trailing" secondItem="ZDv-1m-HBY" secondAttribute="trailing" id="Gz2-5s-Tjd"/>
+                                            <constraint firstItem="ZDv-1m-HBY" firstAttribute="leading" secondItem="0qG-6S-hp3" secondAttribute="leading" id="zWz-OY-7w7"/>
+                                        </constraints>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="HpM-Pp-0un">
+                                        <rect key="frame" x="536" y="0.0" width="94" height="162"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
+                                                <rect key="frame" x="9.6666666666666288" y="0.0" width="75" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
+                                                <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
+                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                            </stepper>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="YJI-ER-LJR" firstAttribute="leading" secondItem="HpM-Pp-0un" secondAttribute="leading" id="Hy7-kp-xcf"/>
+                                            <constraint firstAttribute="trailing" secondItem="YJI-ER-LJR" secondAttribute="trailing" id="mkR-Mm-2bl"/>
+                                            <constraint firstItem="YJI-ER-LJR" firstAttribute="leading" secondItem="HpM-Pp-0un" secondAttribute="leading" id="t9C-Pq-uGY"/>
+                                            <constraint firstAttribute="trailing" secondItem="YJI-ER-LJR" secondAttribute="trailing" id="yrJ-LU-nzd"/>
+                                        </constraints>
+                                    </stackView>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="7MH-0F-wAJ" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="3b9-4B-XnS"/>
+                            <constraint firstItem="7MH-0F-wAJ" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="4ro-xW-Qnb"/>
+                        </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
+                    <navigationItem key="navigationItem" title="재고 추가" id="rO2-xT-2dN">
+                        <barButtonItem key="rightBarButtonItem" title="닫기" id="zYB-4i-afO"/>
+                    </navigationItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
@@ -393,6 +436,8 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" systemColor="systemGray5Color"/>
+                        <color key="barTintColor" red="1" green="0.57810515169999999" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
@@ -404,9 +449,6 @@
             <point key="canvasLocation" x="1637" y="21"/>
         </scene>
     </scenes>
-    <inferredMetricsTieBreakers>
-        <segue reference="URg-3w-vuf"/>
-    </inferredMetricsTieBreakers>
     <resources>
         <namedColor name="AccentColor">
             <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
[@forestjae](https://github.com/forestjae)
안녕하세요~! 숲재!
세번째 리뷰를 요청하게 된 [@rarla](https://github.com/rarlala) [@mond](https://github.com/yeji1008)입니다 :)
이번에도 잘 부탁드립니다~!

## Step3 구현 요구사항
- 화면 제목 '재고 추가' 및 '닫기' 버튼 구현
    - 닫기를 터치하면 이전화면으로 복귀
    - 화면 진입시 과일의 현재 재고 수량 표시
    - -, + 를 통한 재고 수정
- iPhone 12 외에 다른 시뮬레이터에서도 UI가 정상적으로 보일 수 있도록 오토레이아웃 적용
<br><br>

## 코드를 작성하며 고민한 점
- 이번 스템 수행 중 핵심 경험인 아래 항목을 잘 사용하고자 고민했습니다.
    - 내비게이션 바 및 바 버튼 아이템의 활용
    - 얼럿 컨트롤러 활용
    - Stepper 활용
    - Modality의 활용
    - 화면 사이의 데이터 공유
    - 오토레이아웃 시작하기
- 화면 사이의 데이터 공유를 할 때 여러가지 방법 중에서 어떤 것을 사용하면 좋을 지 많은 고민을 해본 결과 재고 수정 페이지로 넘어갈 때는 `segue`를 사용하였고, 데이터 전달을 위해 `present`를 활용했습니다. 그리고 다시 주문 페이지로 넘어갈 때는 `delegate pattern`을 사용하였습니다.
- `ViewController`, `EditStoreViewController` 에서 반복되는 코드를 함수를 이용하여 여러번 작성하지 않도록 하였습니다.
- 성능 향상을 위한 방법으로 `final`, `private` 키워드를 사용하는 것을 배워 적용해보았습니다.

<br><br>

## 조언을 얻고 싶은 부분
- Step2에서 고민한대로 모달로 여는 방법을 선택했습니다. 그러다보니 팝업에서 연결되는 경우에는 navigationBar를 사용할 수 없게 되었습니다. 그래서 임의의 UIView와 Label과 Button으로 제목 영역을 구성했습니다. 이미 제공된 화면에서 네비게이션 컨트롤러가 각각의 화면에 연결이 되어있어 네비게이션 타이틀을 만들 수는 있는 형태였는데, 혹시 팝업에서 열때도 해당 타이틀이 보이게 하는 방법이 있는데 저희가 해당 방식을 알지 못해 구현을 못한 것인지 궁금합니다!
    - 또한 연결되는 질문으로 UIView와 Label과 Button로 제목 영역을 구성한 부분도 UIView가 아닌 `Navigation bar`와 `Navigation item`을 활용해 만드는지 궁금합니다!
- `주문화면 내 재고가 부족하면 표시되는 모달에서 버튼을 클릭하여 재고수정 화면을 여는 방식`과 `주문화면 내 재고 수정 버튼을 클릭해 재고화면을 여는 방식`을 구현하기 위해 segue 방식을 활용해 prepare를 활용하는 방식과 present로 여는 방식 두가지를 사용하였습니다. 혹시 팝업을 열 때와 segue를 사용해 화면을 열 때 하나의 함수를 사용해 해당 코드를 줄이는 방법이 있을지도 궁금합니다.
- `EditStoreViewController` 내 `stepperButtonTapped` 메서드에 중복되는 코드를 줄이고자 노력했습니다. 하지만 각각에 맞는 Label UI 및 Stepper UI에 적용해줘야하는 부분 처리를 더 줄일 방법이 없어 `getChangeNumber` 메서드 분리 정도의 구현만 적용할 수 있었습니다. 혹시 저희가 생각하지 못한 중복된 코드를 줄이는 방법이 있을지 궁금합니다!
- 성능 향상을 위한 방법으로 final, private 키워드를 사용하는 것을 배워 적용해보았습니다. 혹시 제대로 사용을 했는지 궁금합니다.
- @IBOutlet 으로 연결되는 UI들을 하나의 그룹으로 묶어 처리하는 방법이 있는지 궁금합니다!