### PR TITLE
쥬스 자판기  [STEP 1] Andy, Effie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,48 @@
+# Created by https://www.toptal.com/developers/gitignore/api/macos,swift,objective-c,xcode,swiftpackagemanager,cocoapods
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,swift,objective-c,xcode,swiftpackagemanager,cocoapods
+
+### CocoaPods ###
+## CocoaPods GitIgnore Template
+
+# CocoaPods - Only use to conserve bandwidth / Save time on Pushing
+#           - Also handy if you have a large number of dependant pods
+#           - AS PER https://guides.cocoapods.org/using/using-cocoapods.html NEVER IGNORE THE LOCK FILE
+Pods/
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Objective-C ###
 # Xcode
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
@@ -30,48 +75,21 @@ DerivedData/
 *.dSYM.zip
 *.dSYM
 
-## Playgrounds
-timeline.xctimeline
-playground.xcworkspace
-
-# Swift Package Manager
-#
-# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
-# Packages/
-# Package.pins
-# Package.resolved
-# *.xcodeproj
-#
-# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
-# hence it is not needed unless you have added a package configuration file to your project
-# .swiftpm
-
-.build/
-
 # CocoaPods
-#
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
-#
 # Pods/
-#
 # Add this line if you want to avoid checking in source code from the Xcode workspace
 # *.xcworkspace
 
 # Carthage
-#
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
 # Carthage/Checkouts
 
 Carthage/Build/
 
-# Accio dependency management
-Dependencies/
-.accio/
-
 # fastlane
-#
 # It is recommended to not store the screenshots in the git repo.
 # Instead, use fastlane to re-generate the screenshots whenever they are needed.
 # For more information about the recommended setup visit:
@@ -83,8 +101,79 @@ fastlane/screenshots/**/*.png
 fastlane/test_output
 
 # Code Injection
-#
 # After new code Injection tools there's a generated folder /iOSInjectionProject
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+### Objective-C Patch ###
+
+### Swift ###
+# Xcode
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
+.build/
+
+# CocoaPods
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# Pods/
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+
+# Accio dependency management
+Dependencies/
+.accio/
+
+# fastlane
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+
+# Code Injection
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+
+### SwiftPackageManager ###
+# Packages
+# xcuserdata
+# *.xcodeproj
+
+
+### Xcode ###
+
+## Xcode 8 and earlier
+
+### Xcode Patch ###
+# *.xcodeproj/*
+# !*.xcodeproj/project.pbxproj
+# !*.xcodeproj/xcshareddata/
+# !*.xcodeproj/project.xcworkspace/
+# !*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+**/xcshareddata/WorkspaceSettings.xcsettings
+
+# End of https://www.toptal.com/developers/gitignore/api/macos,swift,objective-c,xcode,swiftpackagemanager,cocoapods

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -15,6 +15,10 @@
 		C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3F255D0CDE00020D38 /* Assets.xcassets */; };
 		C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
 		C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */; };
+		F426214F2B1DBEE800C6423A /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = F426214E2B1DBEE800C6423A /* Fruit.swift */; };
+		F42621512B1DBEFD00C6423A /* FruitStock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42621502B1DBEFD00C6423A /* FruitStock.swift */; };
+		F42621532B1DBF2E00C6423A /* JuiceMakerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42621522B1DBF2E00C6423A /* JuiceMakerError.swift */; };
+		F42621552B1DBF3F00C6423A /* JuiceFlavor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42621542B1DBF3F00C6423A /* JuiceFlavor.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +32,10 @@
 		C73DAF42255D0CDF00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C73DAF44255D0CDF00020D38 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMaker.swift; sourceTree = "<group>"; };
+		F426214E2B1DBEE800C6423A /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
+		F42621502B1DBEFD00C6423A /* FruitStock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStock.swift; sourceTree = "<group>"; };
+		F42621522B1DBF2E00C6423A /* JuiceMakerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMakerError.swift; sourceTree = "<group>"; };
+		F42621542B1DBF3F00C6423A /* JuiceFlavor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceFlavor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,6 +64,10 @@
 			children = (
 				C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */,
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
+				F426214E2B1DBEE800C6423A /* Fruit.swift */,
+				F42621502B1DBEFD00C6423A /* FruitStock.swift */,
+				F42621522B1DBF2E00C6423A /* JuiceMakerError.swift */,
+				F42621542B1DBF3F00C6423A /* JuiceFlavor.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -169,6 +181,10 @@
 			files = (
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
 				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
+				F42621552B1DBF3F00C6423A /* JuiceFlavor.swift in Sources */,
+				F42621532B1DBF2E00C6423A /* JuiceMakerError.swift in Sources */,
+				F42621512B1DBEFD00C6423A /* FruitStock.swift in Sources */,
+				F426214F2B1DBEE800C6423A /* Fruit.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,

--- a/JuiceMaker/JuiceMaker/Model/Fruit.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruit.swift
@@ -1,0 +1,14 @@
+//
+//  Fruit.swift
+//  JuiceMaker
+//
+//  Created by Effie on 12/4/23.
+//
+
+enum Fruit: CaseIterable {
+    case strawberry
+    case banana
+    case pineapple
+    case kiwi
+    case mango
+}

--- a/JuiceMaker/JuiceMaker/Model/FruitStock.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStock.swift
@@ -1,0 +1,21 @@
+//
+//  EachFruitStore.swift
+//  JuiceMaker
+//
+//  Created by Effie on 12/4/23.
+//
+
+final class FruitStock {
+    let fruitType: Fruit
+    
+    private var count: Int = 10
+    
+    init(fruitType: Fruit) {
+        self.fruitType = fruitType
+    }
+    
+    func consumeFruits(count: Int) throws {
+        guard self.count >= count else { throw JuiceMakerError.fruitShortage }
+        self.count -= count
+    }
+}

--- a/JuiceMaker/JuiceMaker/Model/FruitStock.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStock.swift
@@ -6,7 +6,7 @@
 //
 
 final class FruitStock {
-    let fruitType: Fruit
+    private let fruitType: Fruit
     
     private var count: Int = 10
     

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -7,6 +7,19 @@
 import Foundation
 
 // 과일 저장소 타입
-class FruitStore {
+final class FruitStore {
+    private var fruitStocks: [Fruit: FruitStock]
     
+    init() {
+        let newFruits: [Fruit: FruitStock] = Fruit.allCases.reduce(into: [:]) { (result, fruit) in
+            let stock = FruitStock(fruitType: fruit)
+            result[fruit] = stock
+        }
+        self.fruitStocks = newFruits
+    }
+    
+    func getFruits(_ fruit: Fruit, count: Int) throws {
+        guard let targetFruitStore = fruitStocks[fruit] else { return }
+        try targetFruitStore.consumeFruits(count: count)
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -4,22 +4,22 @@
 //  Copyright © yagom academy. All rights reserved.
 //
 
-import Foundation
-
-// 과일 저장소 타입
 final class FruitStore {
     private var fruitStocks: [Fruit: FruitStock]
     
     init() {
-        let newFruits: [Fruit: FruitStock] = Fruit.allCases.reduce(into: [:]) { (result, fruit) in
+        let newStocks: [Fruit: FruitStock] = Fruit.allCases.reduce(into: [:]) { (result, fruit) in
             let stock = FruitStock(fruitType: fruit)
             result[fruit] = stock
         }
-        self.fruitStocks = newFruits
+        self.fruitStocks = newStocks
     }
     
-    func getFruits(_ fruit: Fruit, count: Int) throws {
-        guard let targetFruitStore = fruitStocks[fruit] else { return }
-        try targetFruitStore.consumeFruits(count: count)
+    
+    func consume(_ fruitType: Fruit, numberOfFruits: Int) throws {
+        guard let targetFruitStore = fruitStocks[fruitType] else {
+            throw JuiceMakerError.fruitStockNotFound
+        }
+        try targetFruitStore.consumeFruits(count: numberOfFruits)
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceFlavor.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceFlavor.swift
@@ -1,0 +1,35 @@
+//
+//  JuiceFlavor.swift
+//  JuiceMaker
+//
+//  Created by Effie on 12/4/23.
+//
+
+enum JuiceFlavor {
+    case strawberry
+    case banana
+    case pineapple
+    case kiwi
+    case mango
+    case strawberryBanana
+    case mangoKiwi
+    
+    var recipe: [Fruit: Int] {
+        switch self {
+        case .strawberry:
+            return [.strawberry: 16]
+        case .banana:
+            return [.banana: 2]
+        case .pineapple:
+            return [.pineapple: 2]
+        case .kiwi:
+            return [.kiwi: 3]
+        case .mango:
+            return [.mango: 3]
+        case .strawberryBanana:
+            return [.strawberry: 10, .banana: 1]
+        case .mangoKiwi:
+            return [.mango: 2, .kiwi: 1]
+        }
+    }
+}

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -11,7 +11,7 @@ struct JuiceMaker {
         self.fruitStore = fruitStore
     }
     
-    func makeJuice(flavor: JuiceFlavor) throws {
+    func consumeFruitsForMakingJuice(flavor: JuiceFlavor) throws {
         try flavor.recipe.forEach { (fruit: Fruit, count: Int) in
             try fruitStore.consume(fruit, numberOfFruits: count)
         }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -8,5 +8,15 @@ import Foundation
 
 // 쥬스 메이커 타입
 struct JuiceMaker {
+    private let fruitStore: FruitStore
     
+    init(fruitStore: FruitStore) {
+        self.fruitStore = fruitStore
+    }
+    
+    func makeJuice(flavor: JuiceFlavor) throws {
+        try flavor.recipe.forEach { (fruit: Fruit, count: Int) in
+            try fruitStore.getFruits(fruit, count: count)
+        }
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -4,9 +4,6 @@
 //  Copyright © yagom academy. All rights reserved.
 // 
 
-import Foundation
-
-// 쥬스 메이커 타입
 struct JuiceMaker {
     private let fruitStore: FruitStore
     
@@ -16,7 +13,7 @@ struct JuiceMaker {
     
     func makeJuice(flavor: JuiceFlavor) throws {
         try flavor.recipe.forEach { (fruit: Fruit, count: Int) in
-            try fruitStore.getFruits(fruit, count: count)
+            try fruitStore.consume(fruit, numberOfFruits: count)
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMakerError.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMakerError.swift
@@ -1,0 +1,10 @@
+//
+//  JuiceMakerError.swift
+//  JuiceMaker
+//
+//  Created by Effie on 12/4/23.
+//
+
+enum JuiceMakerError: Error {
+    case fruitShortage
+}

--- a/JuiceMaker/JuiceMaker/Model/JuiceMakerError.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMakerError.swift
@@ -7,4 +7,5 @@
 
 enum JuiceMakerError: Error {
     case fruitShortage
+    case fruitStockNotFound
 }


### PR DESCRIPTION
@ictechgy

안녕하세요, 코든! 쥬스 자판기 프로젝트 진행하게 된 에피, 앤디 @nation81 라고 합니다. 첫 리뷰 잘 부탁드립니다.

이번 STEP에서는 프로젝트 시작 전에 함께 결정한 코드 컨벤션 및 프로젝트 룰을 준수하고, 주어진 요구사항에 충실해 객체들의 역할을 직관적으로 전달할 수 있도록 코드를 작성하는 것을 주안으로 두고 작업했습니다.

저희 팀의 코드 컨벤션이나 프로젝트 룰은 다음에 참조해두겠습니다 😃 [wiki - 프로젝트 룰](https://github.com/nation81/Juice-Maker-iOS/wiki/%F0%9F%8D%92-%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-%EB%A3%B0)

## 설계 설명

### Fruit

과일의 종류를 나타내는 타입입니다.

### FruitStock

과일의 종류별 재고를 나타내는 타입입니다.

- 전달된 개수만큼 과일 재고를 차감하는 기능을 포함하고 있습니다.

### FruitStore

모든 과일의 저장소 타입입니다.

- 과일별 과일 재고를 가지고 있습니다. 과일 키를 통해 재고에 접근할 수 있습니다.
- 전달된 과일 종류와 수량만큼의 과일을 재고에서 차감하는 기능을 포함하고 있습니다.

### JuiceFlavor

주스의 종류를 나타내는 타입입니다.

- 주스 종류별로 주스를 만들 때 필요한 과일별 수량을 나타내는 레시피 정보를 가지고 있습니다.

### JuiceMaker

과일 저장소에서 과일을 차감해 주스를 만드는 타입입니다.

- 전달된 주스 종류에 따라 레시피를 참고해 저장소에서 과일 차감하는 주스 만들기 기능을 포함하고 있습니다.

## 질문

### FruitStock 타입 final class / struct 중에 어느 게 어울릴까?

현재 구현에는 FruitStock이 final class로 구현이 되어 있습니다. 

기본 템플릿으로 제공되었던 FruitStore가 class로 제공되었고, reference semantics를 사용해야 하는 상황이 있어서 의도적으로 제공되었을 것이라고 생각했습니다.

final class로 구현했던 이유는 그런 가정 하에, 하위 타입이 일관성 있게 구현되면 좋을 것이라고 생각했기 때문인데요.

그런데 굳이 상속하지도 않고, 반드시 참조 타입으로 사용할 이유가 없다면 구조체 타입을 선택해도 문제가 없을 것이라는 생각이 들더라고요.

혹시 코든은 이런 선택에 대해 어떻게 생각하시는지 궁금합니다.

### FruitStore의 fruitStocks 프로퍼티의 딕셔너리 구현

FruitStock은 과일 종류와 해당 과일 재고를 표현하는 타입이고, FruitStore가 collection으로 소유하게 됩니다.

처음 FruitStock을 구현할 때는 collection 내에서 과일 종류 별로 중복되는 상황을 타입으로 방지하고자 Hashable 구현해서 FruitStore에서 Set으로 소유하도록 구현했었습니다.

```swift
extension FruitStock: Hashable {
    static func == (lhs: FruitStock, rhs: FruitStock) -> Bool {
        lhs.fruitType == rhs.fruitType
    }
    
    func hash(into hasher: inout Hasher) {
        hasher.combine(self.fruitType)
    }
}

class FruitStore {
    private var fruitStocks: Set<FruitStock>
		...
}
```

그런데 FruitStock의 hash 값을 fruitType만으로 결정하는 것이 어색하고 합리적이지 않다고 느껴졌고, 그래서 key로 Fruit을, value로 FruitStock 인스턴스를 갖는 딕셔너리로 구현 변경했습니다.

이렇게 구현하면 집합 안에서 특정 과일 타입으로 stock을 찾을 필요 없이,딕셔너리에 과일 타입으로 접근할 수 있어서 코드가 조금 더 직관적이어 진다고 생각했습니다.

그런데 현재 구현의 경우 딕셔너리에서 전달된 fruit 타입의 stock이 없다면 어떻게 처리해야 하는지 고민이 되기도 하고(현재는 그냥 리턴하고 있습니다), 유일성을 보장하기에 이전 구현이나, [Fruit: Int] 형태의 구현이 더 나은지 고민이 됩니다.

코든은 이 문제에 대해서 어떻게 생각하지는지 궁금합니다!