### PR TITLE
쥬스 자판기 [STEP2] Jane, Harry

### DIFF
--- a/JuiceMaker/JuiceMaker/Constant/Juice.swift
+++ b/JuiceMaker/JuiceMaker/Constant/Juice.swift
@@ -17,8 +17,11 @@ enum Juice: String {
     case mango = "망고쥬스 주문"
     case mangoKiwi = "망키쥬스 주문"
     
-    /// 쥬스 제조 시 필요한 과일 수량 반환하는 메서드
-    var checkFruitQuantity: [Fruit: Int] {
+    var description: String {
+        return rawValue
+    }
+    
+    var requiredFruitQuantity: [Fruit: Int] {
         switch self {
         case .strawberry:
             return [.strawberry: 16]

--- a/JuiceMaker/JuiceMaker/Controller/AppDelegate.swift
+++ b/JuiceMaker/JuiceMaker/Controller/AppDelegate.swift
@@ -27,7 +27,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
-
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
@@ -19,6 +19,10 @@ final class OrderViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         
         configureUI()
     }

--- a/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
@@ -41,6 +41,7 @@ final class OrderViewController: UIViewController {
             configureUI()
             presentMakingJuiceAlert(title: "", message: "\(selectedButtonTitle.replacingOccurrences(of: "쥬스 주문 알림", with: "")) 쥬스 나왔습니다! 맛있게 드세요!", confirmTitle: "확인")
         } catch {
+            presentInventoryAlert(title: "재고 알림", message: "재료가 모자라요. 재고를 수정할까요?", confirmTitle: "예", cancelTitle: "아니오")
         }
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
@@ -24,10 +24,7 @@ final class OrderViewController: UIViewController {
     }
 
     @IBAction private func tapEditInventoryButton(_ sender: UIBarButtonItem) {
-        guard let nextViewController = self.storyboard?.instantiateViewController(withIdentifier: InventoryViewController.className)
-                as? UIViewController else { return }
-        
-        self.navigationController?.pushViewController(nextViewController, animated: true)
+        pushNextViewController()
     }
     
     @IBAction private func tapMakeJuiceButton(_ sender: UIButton) {
@@ -39,9 +36,17 @@ final class OrderViewController: UIViewController {
         do {
             try juiceMaker.makeJuice(juiceType: juice)
             configureUI()
-            presentMakingJuiceAlert(title: "", message: "\(selectedButtonTitle.replacingOccurrences(of: "쥬스 주문 알림", with: "")) 쥬스 나왔습니다! 맛있게 드세요!", confirmTitle: "확인")
+            presentAlert(title: "쥬스 제조 완료",
+                         message: "\(selectedButtonTitle.components(separatedBy: " ").first ?? "") 나왔습니다! 맛있게 드세요",
+                         confirmTitle: "확인")
         } catch {
-            presentInventoryAlert(title: "재고 알림", message: "재료가 모자라요. 재고를 수정할까요?", confirmTitle: "예", cancelTitle: "아니오")
+            presentAlertWithCancel(title: "재고 부족 알림",
+                                   message: "재료가 모자라요. 재고를 수정할까요?",
+                                   confirmTitle: "예",
+                                   cancelTitle: "아니오",
+                                   confirmAction: { _ in
+                self.pushNextViewController()
+            })
         }
     }
     
@@ -51,6 +56,13 @@ final class OrderViewController: UIViewController {
         pineappleQuantityLabel.text = String(fruitStore.fruitContainer[.pineapple, default: 0])
         kiwiQuantityLabel.text = String(fruitStore.fruitContainer[.kiwi, default: 0])
         mangoQuantityLabel.text = String(fruitStore.fruitContainer[.mango, default: 0])
+    }
+    
+    private func pushNextViewController() {
+        guard let nextViewController = self.storyboard?.instantiateViewController(withIdentifier: InventoryViewController.className)
+                as? UIViewController else { return }
+        
+        self.navigationController?.pushViewController(nextViewController, animated: true)
     }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
@@ -8,14 +8,27 @@ import UIKit
 
 final class OrderViewController: UIViewController {
     
-    private let fruitStore = FruitStore.shared
-    private let juiceMaker = JuiceMaker()
-    
     @IBOutlet private weak var strawberryQuantityLabel: UILabel!
     @IBOutlet private weak var bananaQuantityLabel: UILabel!
     @IBOutlet private weak var pineappleQuantityLabel: UILabel!
     @IBOutlet private weak var kiwiQuantityLabel: UILabel!
     @IBOutlet private weak var mangoQuantityLabel: UILabel!
+    
+    private var fruitStore: FruitStore
+    private let juiceMaker: JuiceMaker
+    private lazy var labelsByFruit: [Fruit: UILabel] = [
+        .strawberry: strawberryQuantityLabel,
+        .banana: bananaQuantityLabel,
+        .pineapple: pineappleQuantityLabel,
+        .kiwi: kiwiQuantityLabel,
+        .mango: mangoQuantityLabel
+    ]
+    
+    required init?(coder aDecoder: NSCoder) {
+        self.fruitStore = FruitStore.shared
+        self.juiceMaker = JuiceMaker()
+        super.init(coder: aDecoder)
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -27,8 +40,9 @@ final class OrderViewController: UIViewController {
         configureUI()
     }
 
+    // MARK: @IBAction
     @IBAction private func tapEditInventoryButton(_ sender: UIBarButtonItem) {
-        pushNextViewController()
+        pushInventoryViewController()
     }
     
     @IBAction private func tapMakeJuiceButton(_ sender: UIButton) {
@@ -49,24 +63,24 @@ final class OrderViewController: UIViewController {
                                    confirmTitle: "예",
                                    cancelTitle: "아니오",
                                    confirmAction: { _ in
-                self.pushNextViewController()
+                self.pushInventoryViewController()
             })
         }
     }
+}
+
+extension OrderViewController {
     
     private func configureUI() {
-        strawberryQuantityLabel.text = String(fruitStore.fruitContainer[.strawberry, default: 0])
-        bananaQuantityLabel.text = String(fruitStore.fruitContainer[.banana, default: 0])
-        pineappleQuantityLabel.text = String(fruitStore.fruitContainer[.pineapple, default: 0])
-        kiwiQuantityLabel.text = String(fruitStore.fruitContainer[.kiwi, default: 0])
-        mangoQuantityLabel.text = String(fruitStore.fruitContainer[.mango, default: 0])
+        for (fruit, label) in labelsByFruit {
+            label.text = String(fruitStore.fruitContainer[fruit, default: 0])
+        }
     }
     
-    private func pushNextViewController() {
+    private func pushInventoryViewController() {
         guard let nextViewController = self.storyboard?.instantiateViewController(withIdentifier: InventoryViewController.className)
                 as? UIViewController else { return }
         
         self.navigationController?.pushViewController(nextViewController, animated: true)
     }
 }
-

--- a/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
@@ -39,8 +39,8 @@ final class OrderViewController: UIViewController {
         do {
             try juiceMaker.makeJuice(juiceType: juice)
             configureUI()
+            presentMakingJuiceAlert(title: "", message: "\(selectedButtonTitle.replacingOccurrences(of: "쥬스 주문 알림", with: "")) 쥬스 나왔습니다! 맛있게 드세요!", confirmTitle: "확인")
         } catch {
-            presentAlert(title: "재고가 부족합니다.", message: "다른 쥬스를 선택해주세요.", confirmTitle: "확인")
         }
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
@@ -8,12 +8,14 @@ import UIKit
 
 final class OrderViewController: UIViewController {
     
+    // MARK: @IBOutlet
     @IBOutlet private weak var strawberryQuantityLabel: UILabel!
     @IBOutlet private weak var bananaQuantityLabel: UILabel!
     @IBOutlet private weak var pineappleQuantityLabel: UILabel!
     @IBOutlet private weak var kiwiQuantityLabel: UILabel!
     @IBOutlet private weak var mangoQuantityLabel: UILabel!
     
+    // MARK: Properties
     private var fruitStore: FruitStore
     private let juiceMaker: JuiceMaker
     private lazy var labelsByFruit: [Fruit: UILabel] = [
@@ -24,12 +26,14 @@ final class OrderViewController: UIViewController {
         .mango: mangoQuantityLabel
     ]
     
+    // MARK: Initializer
     required init?(coder aDecoder: NSCoder) {
         self.fruitStore = FruitStore.shared
         self.juiceMaker = JuiceMaker()
         super.init(coder: aDecoder)
     }
     
+    // MARK: Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
     }
@@ -69,6 +73,7 @@ final class OrderViewController: UIViewController {
     }
 }
 
+// MARK: - Custom Methods
 extension OrderViewController {
     
     private func configureUI() {

--- a/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
@@ -66,8 +66,8 @@ final class OrderViewController: UIViewController {
                                    message: "재료가 모자라요. 재고를 수정할까요?",
                                    confirmTitle: "예",
                                    cancelTitle: "아니오",
-                                   confirmAction: { _ in
-                self.pushInventoryViewController()
+                                   confirmAction: { [weak self] _ in
+                self?.pushInventoryViewController()
             })
         }
     }

--- a/JuiceMaker/JuiceMaker/Controller/SceneDelegate.swift
+++ b/JuiceMaker/JuiceMaker/Controller/SceneDelegate.swift
@@ -44,7 +44,5 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
     }
-
-
 }
 

--- a/JuiceMaker/JuiceMaker/Extension/UIViewController + Extension.swift
+++ b/JuiceMaker/JuiceMaker/Extension/UIViewController + Extension.swift
@@ -16,6 +16,9 @@ extension UIViewController {
     var className: String {
         NSStringFromClass(self.classForCoder).components(separatedBy: ".").last!
     }
+}
+
+extension UIViewController {
     
     /// 확인 버튼 하나만 있는 Alert 메서드
     func presentAlert(title: String,
@@ -30,15 +33,15 @@ extension UIViewController {
         
         self.present(alertViewController, animated: true, completion: completion)
     }
-
+    
     /// 확인, 취소 버튼이 있는 Alert 메서드
     func presentAlertWithCancel(title: String,
-                               message: String,
-                               confirmTitle: String,
-                               cancelTitle: String,
-                               confirmAction: ((UIAlertAction) -> Void)? = nil,
-                               cancelAction: ((UIAlertAction) -> Void)? = nil,
-                               completion: (() -> Void)? = nil) {
+                                message: String,
+                                confirmTitle: String,
+                                cancelTitle: String,
+                                confirmAction: ((UIAlertAction) -> Void)? = nil,
+                                cancelAction: ((UIAlertAction) -> Void)? = nil,
+                                completion: (() -> Void)? = nil) {
         let alertViewController = UIAlertController(title: title, message: message, preferredStyle: .alert)
         
         let confirmAction = UIAlertAction(title: confirmTitle, style: .default, handler: confirmAction)

--- a/JuiceMaker/JuiceMaker/Extension/UIViewController + Extension.swift
+++ b/JuiceMaker/JuiceMaker/Extension/UIViewController + Extension.swift
@@ -17,30 +17,36 @@ extension UIViewController {
         NSStringFromClass(self.classForCoder).components(separatedBy: ".").last!
     }
     
-    /// 확인 버튼 Alert 메서드
-    func presentInventoryAlert(title: String, message: String, confirmTitle: String, cancelTitle: String) {
-        let alertViewController = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        
-        let confirmAction = UIAlertAction(title: confirmTitle, style: .default, handler: { _ in
-            guard let nextViewController = self.storyboard?.instantiateViewController(withIdentifier: InventoryViewController.className)
-                    as? UIViewController else { return }
-            
-            self.navigationController?.pushViewController(nextViewController, animated: true)
-        })
-        alertViewController.addAction(confirmAction)
-        
-        let cancelAction = UIAlertAction(title: cancelTitle, style: .cancel)
-        alertViewController.addAction(cancelAction)
-        
-        self.present(alertViewController, animated: true)
-    }
-    
-    func presentMakingJuiceAlert(title: String, message: String, confirmTitle: String) {
+    /// 확인 버튼 하나만 있는 Alert 메서드
+    func presentAlert(title: String,
+                      message: String,
+                      confirmTitle: String,
+                      confirmAction: ((UIAlertAction) -> Void)? = nil,
+                      completion: (() -> Void)? = nil) {
         let alertViewController = UIAlertController(title: title, message: message, preferredStyle: .alert)
         
         let confirmAction = UIAlertAction(title: confirmTitle, style: .default)
         alertViewController.addAction(confirmAction)
         
-        self.present(alertViewController, animated: true)
+        self.present(alertViewController, animated: true, completion: completion)
+    }
+
+    /// 확인, 취소 버튼이 있는 Alert 메서드
+    func presentAlertWithCancel(title: String,
+                               message: String,
+                               confirmTitle: String,
+                               cancelTitle: String,
+                               confirmAction: ((UIAlertAction) -> Void)? = nil,
+                               cancelAction: ((UIAlertAction) -> Void)? = nil,
+                               completion: (() -> Void)? = nil) {
+        let alertViewController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        
+        let confirmAction = UIAlertAction(title: confirmTitle, style: .default, handler: confirmAction)
+        alertViewController.addAction(confirmAction)
+        
+        let cancelAction = UIAlertAction(title: cancelTitle, style: .default, handler: cancelAction)
+        alertViewController.addAction(cancelAction)
+        
+        self.present(alertViewController, animated: true, completion: completion)
     }
 }

--- a/JuiceMaker/JuiceMaker/Extension/UIViewController + Extension.swift
+++ b/JuiceMaker/JuiceMaker/Extension/UIViewController + Extension.swift
@@ -18,10 +18,19 @@ extension UIViewController {
     }
     
     /// 확인 버튼 Alert 메서드
+    func presentInventoryAlert(title: String, message: String, confirmTitle: String, cancelTitle: String) {
         let alertViewController = UIAlertController(title: title, message: message, preferredStyle: .alert)
         
-        let confirmAction = UIAlertAction(title: confirmTitle, style: .default)
+        let confirmAction = UIAlertAction(title: confirmTitle, style: .default, handler: { _ in
+            guard let nextViewController = self.storyboard?.instantiateViewController(withIdentifier: InventoryViewController.className)
+                    as? UIViewController else { return }
+            
+            self.navigationController?.pushViewController(nextViewController, animated: true)
+        })
         alertViewController.addAction(confirmAction)
+        
+        let cancelAction = UIAlertAction(title: cancelTitle, style: .cancel)
+        alertViewController.addAction(cancelAction)
         
         self.present(alertViewController, animated: true)
     }

--- a/JuiceMaker/JuiceMaker/Extension/UIViewController + Extension.swift
+++ b/JuiceMaker/JuiceMaker/Extension/UIViewController + Extension.swift
@@ -18,10 +18,20 @@ extension UIViewController {
     }
     
     /// 확인 버튼 Alert 메서드
-    func presentAlert(title: String, message: String, confirmTitle: String) {
         let alertViewController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        
         let confirmAction = UIAlertAction(title: confirmTitle, style: .default)
         alertViewController.addAction(confirmAction)
+        
+        self.present(alertViewController, animated: true)
+    }
+    
+    func presentMakingJuiceAlert(title: String, message: String, confirmTitle: String) {
+        let alertViewController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        
+        let confirmAction = UIAlertAction(title: confirmTitle, style: .default)
+        alertViewController.addAction(confirmAction)
+        
         self.present(alertViewController, animated: true)
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -12,7 +12,7 @@ struct JuiceMaker {
     private let fruitStore: FruitStore
     
     // MARK: Initializer
-    init(fruitStore: FruitStore = FruitStore.shared) {
+    init(fruitStore: FruitStore = FruitStore.shared, counter: Int = 0) {
         self.fruitStore = fruitStore
     }
     
@@ -21,6 +21,7 @@ struct JuiceMaker {
     /// 쥬스 제조 메서드
     func makeJuice(juiceType: Juice) throws {
         let dic = juiceType.requiredFruitQuantity
+        let originalFruitContainer = fruitStore.fruitContainer
         
         for (fruit, quantity) in dic {
             guard var storedFruit = fruitStore.fruitContainer[fruit] else {
@@ -28,6 +29,7 @@ struct JuiceMaker {
             }
             
             if storedFruit < quantity {
+                fruitStore.fruitContainer = originalFruitContainer
                 throw JuiceMakerError.invalidRequest
             }
             

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -12,7 +12,7 @@ struct JuiceMaker {
     
     /// 쥬스 제조 메서드
     func makeJuice(juiceType: Juice) throws {
-        let dic = juiceType.checkFruitQuantity
+        let dic = juiceType.requiredFruitQuantity
         
         for (fruit, quantity) in dic {
             guard var storedFruit = fruitStore.fruitContainer[fruit] else {

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -8,7 +8,15 @@ import Foundation
 
 struct JuiceMaker {
     
-    private let fruitStore = FruitStore.shared
+    // MARK: Properties
+    private let fruitStore: FruitStore
+    
+    // MARK: Initializer
+    init(fruitStore: FruitStore = FruitStore.shared) {
+        self.fruitStore = fruitStore
+    }
+    
+    // MARK: Custom Methods
     
     /// 쥬스 제조 메서드
     func makeJuice(juiceType: Juice) throws {

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -280,104 +280,123 @@
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                <rect key="frame" x="590" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                <rect key="frame" x="622" y="156" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                <rect key="frame" x="580" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                <rect key="frame" x="429" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                <rect key="frame" x="461" y="156" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                <rect key="frame" x="410" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                <rect key="frame" x="271" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                <rect key="frame" x="303" y="155" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                <rect key="frame" x="261" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                <rect key="frame" x="165" y="73" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                <rect key="frame" x="154" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                <rect key="frame" x="98" y="161" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                <rect key="frame" x="60" y="73" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                <rect key="frame" x="196" y="158" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                <rect key="frame" x="50" y="192" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stepper>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="88c-7u-0S3">
+                                <rect key="frame" x="107" y="114" width="630" height="162"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="E5h-m1-ct6">
+                                        <rect key="frame" x="0.0" y="0.0" width="94" height="162"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
+                                                <rect key="frame" x="9.6666666666666714" y="0.0" width="75" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
+                                                <rect key="frame" x="40.333333333333343" y="93.666666666666657" width="13.333333333333336" height="26.333333333333329"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
+                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="aU8-eN-YVM">
+                                        <rect key="frame" x="134" y="0.0" width="94" height="162"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
+                                                <rect key="frame" x="9.6666666666666572" y="0.0" width="75" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
+                                                <rect key="frame" x="40.333333333333314" y="93.666666666666657" width="13.333333333333336" height="26.333333333333329"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
+                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Cur-Ul-zXl">
+                                        <rect key="frame" x="268" y="0.0" width="94" height="162"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
+                                                <rect key="frame" x="9.6666666666666856" y="0.0" width="75" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
+                                                <rect key="frame" x="40.333333333333314" y="93.666666666666657" width="13.333333333333336" height="26.333333333333329"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
+                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="sSW-TW-5vr">
+                                        <rect key="frame" x="402" y="0.0" width="94" height="162"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
+                                                <rect key="frame" x="9.6666666666666288" y="0.0" width="75" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
+                                                <rect key="frame" x="40.333333333333371" y="93.666666666666657" width="13.333333333333336" height="26.333333333333329"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
+                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="OeC-fi-47F">
+                                        <rect key="frame" x="536" y="0.0" width="94" height="162"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
+                                                <rect key="frame" x="9.6666666666666288" y="0.0" width="75" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
+                                                <rect key="frame" x="40.333333333333371" y="93.666666666666657" width="13.333333333333336" height="26.333333333333329"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
+                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="88c-7u-0S3" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="JzW-6e-zk3"/>
+                            <constraint firstItem="88c-7u-0S3" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="OFj-Y7-R4V"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
                 </viewController>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -19,19 +19,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="16" y="98.999999999999986" width="812" height="136.66666666666663"/>
+                                <rect key="frame" x="63" y="63.999999999999986" width="718" height="136.66666666666663"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="136.66666666666666"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -40,16 +40,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="165.66666666666669" y="0.0" width="149.66666666666669" height="136.66666666666666"/>
+                                        <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -58,16 +58,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="331.33333333333331" y="0.0" width="149.33333333333331" height="136.66666666666666"/>
+                                        <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="149.33333333333334" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.33333333333334" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -76,16 +76,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="496.66666666666669" y="0.0" width="149.66666666666669" height="136.66666666666666"/>
+                                        <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -94,16 +94,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="662.33333333333337" y="0.0" width="149.66666666666663" height="136.66666666666666"/>
+                                        <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -114,13 +114,13 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="16" y="255.66666666666666" width="812" height="80.333333333333343"/>
+                                <rect key="frame" x="63" y="220.66666666666663" width="718" height="128.33333333333331"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="812" height="36"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="718" height="60"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="315.33333333333331" height="36"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="277.66666666666669" height="60"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="딸바쥬스 주문">
@@ -131,11 +131,11 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
-                                                <rect key="frame" x="331.33333333333331" y="0.0" width="149.33333333333331" height="36"/>
+                                                <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="60"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="496.66666666666663" y="0.0" width="315.33333333333337" height="36"/>
+                                                <rect key="frame" x="440.33333333333326" y="0.0" width="277.66666666666674" height="60"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
@@ -148,13 +148,13 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="44.000000000000028" width="812" height="36.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="68.000000000000028" width="718" height="60.333333333333343"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="812" height="36.333333333333336"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="718" height="60.333333333333336"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="36.333333333333336"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="60.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="딸기쥬스 주문">
@@ -165,7 +165,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="165.66666666666669" y="0.0" width="149.66666666666669" height="36.333333333333336"/>
+                                                        <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="60.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="바나나쥬스 주문">
@@ -176,7 +176,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
-                                                        <rect key="frame" x="331.33333333333331" y="0.0" width="149.33333333333331" height="36.333333333333336"/>
+                                                        <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="60.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="파인애플쥬스 주문">
@@ -187,7 +187,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="496.66666666666669" y="0.0" width="149.66666666666669" height="36.333333333333336"/>
+                                                        <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="60.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="키위쥬스 주문">
@@ -198,7 +198,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                        <rect key="frame" x="662.33333333333337" y="0.0" width="149.66666666666663" height="36.333333333333336"/>
+                                                        <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="60.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="망고쥬스 주문">
@@ -260,7 +260,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DCG-dP-Fms" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="wpg-nM-F9y">
-                        <rect key="frame" x="0.0" y="47" width="844" height="32"/>
+                        <rect key="frame" x="0.0" y="0.0" width="844" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -287,7 +287,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="94" height="162"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                                <rect key="frame" x="9.6666666666666714" y="0.0" width="75.000000000000014" height="83.666666666666671"/>
+                                                <rect key="frame" x="9.6666666666666714" y="0.0" width="75" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -301,6 +301,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                                 <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="modifyFruitStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="A2b-8w-AWl"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
@@ -322,6 +325,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
                                                 <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="modifyFruitStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="kMH-E1-P8j"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
@@ -343,6 +349,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
                                                 <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="modifyFruitStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="LH3-rl-naO"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
@@ -364,6 +373,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
                                                 <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="modifyFruitStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="LQC-rO-dFs"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
@@ -385,6 +397,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
                                                 <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="modifyFruitStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="JZ7-E5-m6Z"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
@@ -401,10 +416,15 @@
                     <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
                     <connections>
                         <outlet property="bananaQuantityLabel" destination="gKu-86-RhI" id="svr-4z-HT5"/>
+                        <outlet property="bananaStepper" destination="O5s-2N-3iP" id="Kmb-wk-cQo"/>
                         <outlet property="kiwiQuantityLabel" destination="ZDv-1m-HBY" id="HXb-lW-hyy"/>
+                        <outlet property="kiwiStepper" destination="klA-59-Nu4" id="dIz-cc-HJL"/>
                         <outlet property="mangoQuantityLabel" destination="YJI-ER-LJR" id="758-p1-iQ1"/>
+                        <outlet property="mangoStepper" destination="xbn-6P-grO" id="IE9-nZ-C6u"/>
                         <outlet property="pineappleQuantityLabel" destination="MpT-VW-hCb" id="vOL-H3-fvD"/>
+                        <outlet property="pineappleStepper" destination="Rcr-xr-eqz" id="bJS-g0-V08"/>
                         <outlet property="strawberryQuantityLabel" destination="0yV-kn-zaT" id="Sd5-4x-i5X"/>
+                        <outlet property="strawberryStepper" destination="ZQk-f4-zrz" id="bXh-cQ-gzj"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
@@ -420,7 +440,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGray5Color">
-            <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -19,19 +19,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="63" y="63.999999999999986" width="718" height="136.66666666666663"/>
+                                <rect key="frame" x="16" y="98.999999999999986" width="812" height="136.66666666666663"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="136.66666666666666"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -40,16 +40,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="136.66666666666666"/>
+                                        <rect key="frame" x="165.66666666666669" y="0.0" width="149.66666666666669" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -58,16 +58,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="136.66666666666666"/>
+                                        <rect key="frame" x="331.33333333333331" y="0.0" width="149.33333333333331" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="149.33333333333334" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.33333333333334" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -76,16 +76,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="136.66666666666666"/>
+                                        <rect key="frame" x="496.66666666666669" y="0.0" width="149.66666666666669" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -94,16 +94,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="136.66666666666666"/>
+                                        <rect key="frame" x="662.33333333333337" y="0.0" width="149.66666666666663" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -114,13 +114,13 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="63" y="220.66666666666663" width="718" height="128.33333333333331"/>
+                                <rect key="frame" x="16" y="255.66666666666666" width="812" height="80.333333333333343"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="718" height="60"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="812" height="36"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="277.66666666666669" height="60"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="315.33333333333331" height="36"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="딸바쥬스 주문">
@@ -131,11 +131,11 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
-                                                <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="60"/>
+                                                <rect key="frame" x="331.33333333333331" y="0.0" width="149.33333333333331" height="36"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="440.33333333333326" y="0.0" width="277.66666666666674" height="60"/>
+                                                <rect key="frame" x="496.66666666666663" y="0.0" width="315.33333333333337" height="36"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
@@ -148,13 +148,13 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="68.000000000000028" width="718" height="60.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="44.000000000000028" width="812" height="36.333333333333343"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="718" height="60.333333333333336"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="812" height="36.333333333333336"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="60.333333333333336"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="36.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="딸기쥬스 주문">
@@ -165,7 +165,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="60.333333333333336"/>
+                                                        <rect key="frame" x="165.66666666666669" y="0.0" width="149.66666666666669" height="36.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="바나나쥬스 주문">
@@ -176,7 +176,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
-                                                        <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="60.333333333333336"/>
+                                                        <rect key="frame" x="331.33333333333331" y="0.0" width="149.33333333333331" height="36.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="파인애플쥬스 주문">
@@ -187,7 +187,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="60.333333333333336"/>
+                                                        <rect key="frame" x="496.66666666666669" y="0.0" width="149.66666666666669" height="36.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="키위쥬스 주문">
@@ -198,7 +198,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                        <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="60.333333333333336"/>
+                                                        <rect key="frame" x="662.33333333333337" y="0.0" width="149.66666666666663" height="36.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="망고쥬스 주문">
@@ -260,7 +260,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DCG-dP-Fms" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="wpg-nM-F9y">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="44"/>
+                        <rect key="frame" x="0.0" y="47" width="844" height="32"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -287,7 +287,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="94" height="162"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                                <rect key="frame" x="9.6666666666666714" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="9.6666666666666714" y="0.0" width="75.000000000000014" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -302,7 +302,7 @@
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                                 <rect key="frame" x="0.0" y="130" width="94" height="32"/>
                                                 <connections>
-                                                    <action selector="modifyFruitStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="A2b-8w-AWl"/>
+                                                    <action selector="tapStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="nv1-8X-Omw"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
@@ -326,7 +326,7 @@
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
                                                 <rect key="frame" x="0.0" y="130" width="94" height="32"/>
                                                 <connections>
-                                                    <action selector="modifyFruitStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="kMH-E1-P8j"/>
+                                                    <action selector="tapStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="zWR-3h-WOS"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
@@ -350,7 +350,7 @@
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
                                                 <rect key="frame" x="0.0" y="130" width="94" height="32"/>
                                                 <connections>
-                                                    <action selector="modifyFruitStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="LH3-rl-naO"/>
+                                                    <action selector="tapStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="5K5-jk-tdp"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
@@ -374,7 +374,7 @@
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
                                                 <rect key="frame" x="0.0" y="130" width="94" height="32"/>
                                                 <connections>
-                                                    <action selector="modifyFruitStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="LQC-rO-dFs"/>
+                                                    <action selector="tapStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="WYS-mI-VUz"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
@@ -398,7 +398,7 @@
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
                                                 <rect key="frame" x="0.0" y="130" width="94" height="32"/>
                                                 <connections>
-                                                    <action selector="modifyFruitStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="JZ7-E5-m6Z"/>
+                                                    <action selector="tapStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="cTe-Hs-92N"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
@@ -440,7 +440,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGray5Color">
-            <color red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -19,19 +19,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="63" y="63.999999999999986" width="718" height="136.66666666666663"/>
+                                <rect key="frame" x="16" y="98.999999999999986" width="812" height="136.66666666666663"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="136.66666666666666"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -40,16 +40,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="136.66666666666666"/>
+                                        <rect key="frame" x="165.66666666666669" y="0.0" width="149.66666666666669" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -58,16 +58,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="136.66666666666666"/>
+                                        <rect key="frame" x="331.33333333333331" y="0.0" width="149.33333333333331" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="149.33333333333334" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.33333333333334" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -76,16 +76,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="136.66666666666666"/>
+                                        <rect key="frame" x="496.66666666666669" y="0.0" width="149.66666666666669" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -94,16 +94,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="136.66666666666666"/>
+                                        <rect key="frame" x="662.33333333333337" y="0.0" width="149.66666666666663" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -114,13 +114,13 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="63" y="220.66666666666663" width="718" height="128.33333333333337"/>
+                                <rect key="frame" x="16" y="255.66666666666666" width="812" height="80.333333333333343"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="718" height="60"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="812" height="36"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="277.66666666666669" height="60"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="315.33333333333331" height="36"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="딸바쥬스 주문">
@@ -131,11 +131,11 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
-                                                <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="60"/>
+                                                <rect key="frame" x="331.33333333333331" y="0.0" width="149.33333333333331" height="36"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="440.33333333333326" y="0.0" width="277.66666666666674" height="60"/>
+                                                <rect key="frame" x="496.66666666666663" y="0.0" width="315.33333333333337" height="36"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
@@ -148,13 +148,13 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="68.000000000000028" width="718" height="60.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="44.000000000000028" width="812" height="36.333333333333343"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="718" height="60.333333333333336"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="812" height="36.333333333333336"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="60.333333333333336"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="36.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="딸기쥬스 주문">
@@ -165,7 +165,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="60.333333333333336"/>
+                                                        <rect key="frame" x="165.66666666666669" y="0.0" width="149.66666666666669" height="36.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="바나나쥬스 주문">
@@ -176,7 +176,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
-                                                        <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="60.333333333333336"/>
+                                                        <rect key="frame" x="331.33333333333331" y="0.0" width="149.33333333333331" height="36.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="파인애플쥬스 주문">
@@ -187,7 +187,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="60.333333333333336"/>
+                                                        <rect key="frame" x="496.66666666666669" y="0.0" width="149.66666666666669" height="36.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="키위쥬스 주문">
@@ -198,7 +198,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                        <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="60.333333333333336"/>
+                                                        <rect key="frame" x="662.33333333333337" y="0.0" width="149.66666666666663" height="36.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="망고쥬스 주문">
@@ -260,7 +260,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DCG-dP-Fms" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="wpg-nM-F9y">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="44"/>
+                        <rect key="frame" x="0.0" y="47" width="844" height="32"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -287,7 +287,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="94" height="162"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                                <rect key="frame" x="9.6666666666666714" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="9.6666666666666714" y="0.0" width="75.000000000000014" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -399,6 +399,13 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
+                    <connections>
+                        <outlet property="bananaQuantityLabel" destination="gKu-86-RhI" id="svr-4z-HT5"/>
+                        <outlet property="kiwiQuantityLabel" destination="ZDv-1m-HBY" id="HXb-lW-hyy"/>
+                        <outlet property="mangoQuantityLabel" destination="YJI-ER-LJR" id="758-p1-iQ1"/>
+                        <outlet property="pineappleQuantityLabel" destination="MpT-VW-hCb" id="vOL-H3-fvD"/>
+                        <outlet property="strawberryQuantityLabel" destination="0yV-kn-zaT" id="Sd5-4x-i5X"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
@@ -413,7 +420,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGray5Color">
-            <color red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 final class InventoryViewController: UIViewController {
     
+    // MARK: @IBOutlet
     @IBOutlet private weak var strawberryQuantityLabel: UILabel!
     @IBOutlet private weak var bananaQuantityLabel: UILabel!
     @IBOutlet private weak var pineappleQuantityLabel: UILabel!
@@ -20,6 +21,7 @@ final class InventoryViewController: UIViewController {
     @IBOutlet private weak var kiwiStepper: UIStepper!
     @IBOutlet private weak var mangoStepper: UIStepper!
     
+    // MARK: Properties
     private var fruitStore: FruitStore
     private lazy var componentsByFruit: [Fruit: (label: UILabel, stepper: UIStepper)] = [
         .strawberry: (strawberryQuantityLabel, strawberryStepper),
@@ -37,22 +39,26 @@ final class InventoryViewController: UIViewController {
         mangoStepper: mangoQuantityLabel
     ]
     
+    // MARK: Initializer
     required init?(coder aDecoder: NSCoder) {
         self.fruitStore = FruitStore.shared
         super.init(coder: aDecoder)
     }
     
+    // MARK: Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
         
         configureUI()
     }
     
+    // MARK: @IBAction
     @IBAction private func modifyFruitStepper(_ sender: UIStepper) {
         updateFruitQuantity(sender)
     }
 }
 
+// MARK: - Custom Methods
 extension InventoryViewController {
     
     private func configureUI() {

--- a/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
@@ -8,60 +8,59 @@
 import UIKit
 
 final class InventoryViewController: UIViewController {
-
-    private let fruitStore = FruitStore.shared
     
     @IBOutlet weak var strawberryQuantityLabel: UILabel!
     @IBOutlet weak var bananaQuantityLabel: UILabel!
     @IBOutlet weak var pineappleQuantityLabel: UILabel!
     @IBOutlet weak var kiwiQuantityLabel: UILabel!
     @IBOutlet weak var mangoQuantityLabel: UILabel!
-    
     @IBOutlet weak var strawberryStepper: UIStepper!
     @IBOutlet weak var bananaStepper: UIStepper!
     @IBOutlet weak var pineappleStepper: UIStepper!
     @IBOutlet weak var kiwiStepper: UIStepper!
     @IBOutlet weak var mangoStepper: UIStepper!
     
-    private lazy var fruitQuantityLabels: [Fruit: UILabel] = [
-        .strawberry: strawberryQuantityLabel,
-        .banana: bananaQuantityLabel,
-        .pineapple: pineappleQuantityLabel,
-        .kiwi: kiwiQuantityLabel,
-        .mango: mangoQuantityLabel
+    private var fruitStore: FruitStore
+    
+    private lazy var componentsByFruit: [Fruit: (label: UILabel, stepper: UIStepper)] = [
+        .strawberry: (strawberryQuantityLabel, strawberryStepper),
+        .banana: (bananaQuantityLabel, bananaStepper),
+        .pineapple: (pineappleQuantityLabel, pineappleStepper),
+        .kiwi: (kiwiQuantityLabel, kiwiStepper),
+        .mango: (mangoQuantityLabel, mangoStepper)
     ]
     
-    private lazy var fruitSteppers: [UIStepper: Fruit] = [
-        strawberryStepper: .strawberry,
-        bananaStepper: .banana,
-        pineappleStepper: .pineapple,
-        kiwiStepper: .kiwi,
-        mangoStepper: .mango
+    private lazy var labelsByStepper: [UIStepper: UILabel] = [
+        strawberryStepper: strawberryQuantityLabel,
+        bananaStepper: bananaQuantityLabel,
+        pineappleStepper: pineappleQuantityLabel,
+        kiwiStepper: kiwiQuantityLabel,
+        mangoStepper: mangoQuantityLabel
     ]
+    
+    required init?(coder aDecoder: NSCoder) {
+        self.fruitStore = FruitStore.shared
+        super.init(coder: aDecoder)
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         configureUI()
-        configureInitialStepperValue()
     }
     
     @IBAction func modifyFruitStepper(_ sender: UIStepper) {
-        if let fruit = fruitSteppers[sender] {
-            fruitStore.fruitContainer[fruit] = Int(sender.value)
-            fruitQuantityLabels[fruit]?.text = String(format: "%.0f", sender.value)
-        }
+        updateFruitQuantity(sender)
     }
     
     private func configureUI() {
-        for (fruit, label) in fruitQuantityLabels {
-            label.text = String(fruitStore.fruitContainer[fruit, default: 0])
+        for (fruit, component) in componentsByFruit {
+            component.label.text = String(fruitStore.fruitContainer[fruit, default: 0])
+            component.stepper.value = Double(fruitStore.fruitContainer[fruit, default: 0])
         }
     }
     
-    private func configureInitialStepperValue() {
-        for (stepper, fruit) in fruitSteppers {
-            stepper.value = Double(fruitStore.fruitContainer[fruit, default: 0])
-        }
+    private func updateFruitQuantity(_ stepper: UIStepper) {
+        labelsByStepper[stepper]?.text = String(Int(stepper.value))
     }
 }

--- a/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
@@ -9,19 +9,18 @@ import UIKit
 
 final class InventoryViewController: UIViewController {
     
-    @IBOutlet weak var strawberryQuantityLabel: UILabel!
-    @IBOutlet weak var bananaQuantityLabel: UILabel!
-    @IBOutlet weak var pineappleQuantityLabel: UILabel!
-    @IBOutlet weak var kiwiQuantityLabel: UILabel!
-    @IBOutlet weak var mangoQuantityLabel: UILabel!
-    @IBOutlet weak var strawberryStepper: UIStepper!
-    @IBOutlet weak var bananaStepper: UIStepper!
-    @IBOutlet weak var pineappleStepper: UIStepper!
-    @IBOutlet weak var kiwiStepper: UIStepper!
-    @IBOutlet weak var mangoStepper: UIStepper!
+    @IBOutlet private weak var strawberryQuantityLabel: UILabel!
+    @IBOutlet private weak var bananaQuantityLabel: UILabel!
+    @IBOutlet private weak var pineappleQuantityLabel: UILabel!
+    @IBOutlet private weak var kiwiQuantityLabel: UILabel!
+    @IBOutlet private weak var mangoQuantityLabel: UILabel!
+    @IBOutlet private weak var strawberryStepper: UIStepper!
+    @IBOutlet private weak var bananaStepper: UIStepper!
+    @IBOutlet private weak var pineappleStepper: UIStepper!
+    @IBOutlet private weak var kiwiStepper: UIStepper!
+    @IBOutlet private weak var mangoStepper: UIStepper!
     
     private var fruitStore: FruitStore
-    
     private lazy var componentsByFruit: [Fruit: (label: UILabel, stepper: UIStepper)] = [
         .strawberry: (strawberryQuantityLabel, strawberryStepper),
         .banana: (bananaQuantityLabel, bananaStepper),
@@ -49,14 +48,17 @@ final class InventoryViewController: UIViewController {
         configureUI()
     }
     
-    @IBAction func modifyFruitStepper(_ sender: UIStepper) {
+    @IBAction private func modifyFruitStepper(_ sender: UIStepper) {
         updateFruitQuantity(sender)
     }
+}
+
+extension InventoryViewController {
     
     private func configureUI() {
-        for (fruit, component) in componentsByFruit {
-            component.label.text = String(fruitStore.fruitContainer[fruit, default: 0])
-            component.stepper.value = Double(fruitStore.fruitContainer[fruit, default: 0])
+        for (fruit, components) in componentsByFruit {
+            components.label.text = String(fruitStore.fruitContainer[fruit, default: 0])
+            components.stepper.value = Double(fruitStore.fruitContainer[fruit, default: 0])
         }
     }
     

--- a/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
@@ -9,7 +9,25 @@ import UIKit
 
 final class InventoryViewController: UIViewController {
 
+    private let fruitStore = FruitStore.shared
+    
+    @IBOutlet weak var strawberryQuantityLabel: UILabel!
+    @IBOutlet weak var bananaQuantityLabel: UILabel!
+    @IBOutlet weak var pineappleQuantityLabel: UILabel!
+    @IBOutlet weak var kiwiQuantityLabel: UILabel!
+    @IBOutlet weak var mangoQuantityLabel: UILabel!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        configureUI()
+    }
+    
+    private func configureUI() {
+        strawberryQuantityLabel.text = String(fruitStore.fruitContainer[.strawberry, default: 0])
+        bananaQuantityLabel.text = String(fruitStore.fruitContainer[.banana, default: 0])
+        pineappleQuantityLabel.text = String(fruitStore.fruitContainer[.pineapple, default: 0])
+        kiwiQuantityLabel.text = String(fruitStore.fruitContainer[.kiwi, default: 0])
+        mangoQuantityLabel.text = String(fruitStore.fruitContainer[.mango, default: 0])
     }
 }

--- a/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
@@ -31,12 +31,12 @@ final class InventoryViewController: UIViewController {
         .mango: (mangoQuantityLabel, mangoStepper)
     ]
     
-    private lazy var labelsByStepper: [UIStepper: UILabel] = [
-        strawberryStepper: strawberryQuantityLabel,
-        bananaStepper: bananaQuantityLabel,
-        pineappleStepper: pineappleQuantityLabel,
-        kiwiStepper: kiwiQuantityLabel,
-        mangoStepper: mangoQuantityLabel
+    private lazy var fruitElementsByStepper: [UIStepper: (label: UILabel, fruit: Fruit)] = [
+        strawberryStepper: (strawberryQuantityLabel, .strawberry),
+        bananaStepper: (bananaQuantityLabel, .banana),
+        pineappleStepper: (pineappleQuantityLabel, .pineapple),
+        kiwiStepper: (kiwiQuantityLabel, .kiwi),
+        mangoStepper: (mangoQuantityLabel, .mango)
     ]
     
     // MARK: Initializer
@@ -52,9 +52,11 @@ final class InventoryViewController: UIViewController {
         configureUI()
     }
     
-    // MARK: @IBAction
-    @IBAction private func modifyFruitStepper(_ sender: UIStepper) {
-        updateFruitQuantity(sender)
+    @IBAction func tapStepper(_ sender: UIStepper) {
+        guard let fruit = fruitElementsByStepper[sender]?.fruit else {
+            return
+        }
+        updateFruitQuantity(sender, fruit)
     }
 }
 
@@ -68,7 +70,8 @@ extension InventoryViewController {
         }
     }
     
-    private func updateFruitQuantity(_ stepper: UIStepper) {
-        labelsByStepper[stepper]?.text = String(Int(stepper.value))
+    private func updateFruitQuantity(_ stepper: UIStepper, _ fruit: Fruit) {
+        fruitElementsByStepper[stepper]?.label.text = String(Int(stepper.value))
+        fruitStore.fruitContainer[fruit] = Int(stepper.value)
     }
 }

--- a/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
@@ -65,8 +65,9 @@ extension InventoryViewController {
     
     private func configureUI() {
         for (fruit, components) in componentsByFruit {
-            components.label.text = String(fruitStore.fruitContainer[fruit, default: 0])
-            components.stepper.value = Double(fruitStore.fruitContainer[fruit, default: 0])
+            let fruitQuantity: Int = fruitStore.fruitContainer[fruit, default: 0]
+            components.label.text = String(fruitQuantity)
+            components.stepper.value = Double(fruitQuantity)
         }
     }
     

--- a/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
@@ -17,17 +17,51 @@ final class InventoryViewController: UIViewController {
     @IBOutlet weak var kiwiQuantityLabel: UILabel!
     @IBOutlet weak var mangoQuantityLabel: UILabel!
     
+    @IBOutlet weak var strawberryStepper: UIStepper!
+    @IBOutlet weak var bananaStepper: UIStepper!
+    @IBOutlet weak var pineappleStepper: UIStepper!
+    @IBOutlet weak var kiwiStepper: UIStepper!
+    @IBOutlet weak var mangoStepper: UIStepper!
+    
+    private lazy var fruitQuantityLabels: [Fruit: UILabel] = [
+        .strawberry: strawberryQuantityLabel,
+        .banana: bananaQuantityLabel,
+        .pineapple: pineappleQuantityLabel,
+        .kiwi: kiwiQuantityLabel,
+        .mango: mangoQuantityLabel
+    ]
+    
+    private lazy var fruitSteppers: [UIStepper: Fruit] = [
+        strawberryStepper: .strawberry,
+        bananaStepper: .banana,
+        pineappleStepper: .pineapple,
+        kiwiStepper: .kiwi,
+        mangoStepper: .mango
+    ]
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
         configureUI()
+        configureInitialStepperValue()
+    }
+    
+    @IBAction func modifyFruitStepper(_ sender: UIStepper) {
+        if let fruit = fruitSteppers[sender] {
+            fruitStore.fruitContainer[fruit] = Int(sender.value)
+            fruitQuantityLabels[fruit]?.text = String(format: "%.0f", sender.value)
+        }
     }
     
     private func configureUI() {
-        strawberryQuantityLabel.text = String(fruitStore.fruitContainer[.strawberry, default: 0])
-        bananaQuantityLabel.text = String(fruitStore.fruitContainer[.banana, default: 0])
-        pineappleQuantityLabel.text = String(fruitStore.fruitContainer[.pineapple, default: 0])
-        kiwiQuantityLabel.text = String(fruitStore.fruitContainer[.kiwi, default: 0])
-        mangoQuantityLabel.text = String(fruitStore.fruitContainer[.mango, default: 0])
+        for (fruit, label) in fruitQuantityLabels {
+            label.text = String(fruitStore.fruitContainer[fruit, default: 0])
+        }
+    }
+    
+    private func configureInitialStepperValue() {
+        for (stepper, fruit) in fruitSteppers {
+            stepper.value = Double(fruitStore.fruitContainer[fruit, default: 0])
+        }
     }
 }


### PR DESCRIPTION
@junbangg

안녕하세요~ 알라딘! Jane, Harry입니다! 
STEP2 PR을 드리며 바쁘신 와중에 리뷰해주셔서 감사드려요!
조언, 제안 모두 언제나 환영합니다! 🥹
감사합니다!

## 🔍 What is this PR?

STEP 2의 기능을 구현했습니다.

- 재고 관리 화면 기능 및 오토 레이아웃 구현
- 재고 관리 화면 Stepper 기능 구현
- 쥬스 제조 및 재고 부족 시 Alert 구현

## 📝 PR Point

### `Singleton` 객체 외부 주입

기존 Step1에서 싱글톤 패턴으로 구현한 `FruitStore` 객체의 의존성을 외부에서 주입하는 방식으로 변경해 객체 간 결합도를 낮추고자 했습니다. 

### 초기 화면 - **쥬스 제조 완료시 `alert` 표시**
`UIViewController` extension 에 `alert` 생성 메서드를 정의하고, 
`ViewController` 에서 `쥬스 제조 완료`, `쥬스 재고 확인` 케이스 별 적절한 alert 창을 호출해 상황별로 사용자에게 적절한 메시지를 보여주고, 알맞은 화면 전환이 수행될 수 있도록 했습니다.
 
### 재고관리 - `Dictionary` 타입 활용
stepper 이벤트 발생 시 싱글톤 데이터의 알맞은 과일 재고 수량 변경, UI 업데이트 등의 작업 처리를 위해 `Dictionary` 타입을 활용했습니다. key 값에 해당하는 값을 빠르게 검색할 수 있다는 `Dictonary` 자료 구조의 장점을 활용해 이벤트 발생 시 key에 해당하는 value 의 데이터나 UI가 변경될 수 있도록 했습니다.

## 📸 Screenshot
구현 내용 | 구동 영상
-- | --
구동화면 | ![Simulator Screen Recording - iPhone 15 - 2023-12-13 at 19 55 04](https://github.com/tasty-code/ios-juice-maker/assets/83139316/db217898-349e-4f53-b5fc-b6061a71e2e4) | 


## **+** 질문 및 고민한 부분

**From. Harry(@hemil0102)**

1. Juice 열거형 내부에 rawValue 처리를 아래 코드와 같이 연산 프로퍼티로 접근하게 만들어주었습니다. 말씀해주신게 이 방향이 맞을까요?

```swift
enum Juice: String {
    case strawberry = "딸기쥬스 주문"
    case banana = "바나나쥬스 주문"
    case kiwi = "키위쥬스 주문"
    case pineapple = "파인애플쥬스 주문"
    case strawberryBanana = "딸바쥬스 주문"
    case mango = "망고쥬스 주문"
    case mangoKiwi = "망키쥬스 주문"
    
    var description: String {
        return rawValue
    }
```

2. 버튼과 스태퍼를 하나의 함수로 구현을 해주었습니다. 각각의 컴포넌트들을 개별적인 @IBAction으로 처리하는 것은 코드가 길어져서 하나로 합쳤는데, 가독성 측면에서는 합친 것이 나빠진 것 같기도 합니다. 비슷한 컴포넌트를 개별처리하는 것과 배열이나 함수 하나에 묶어서 관리하는 것 중에 어떤 것을 더 선호하시나요? 

**From. Jane(@jane1choi)**

1. `OrderViewController -> InventoryViewController` 화면전환 방식

사실…개인적인 의견이지만.. HIG를 기반으로 생각해봤을 때 modal 방식이 좀 더 적합하다고 생각하긴하는데,,, 프로젝트 파일에 기본으로 `navigation bar` 가 생성되어있었고, 가로 화면에서 modal로 다음화면을 present 해주니 presentationStyle 설정을 다른 방식으로 해주어도 뒷 화면을 아예 가려버리는 방식으로 화면전환이 되더라구요…그래서 일단 구현은 navigation 방식의 화면전환으로 처리해두었는데 해당 플로우에서 적합한 화면 전환 방식에 대한 리뷰어님의 의견도 궁금합니다!

참고한 HIG 파트 - Patterns > Modality

```
모달리티(modality)는 부모 뷰와의 상호 작용을 방지하고 거부하기 위한 명시적인 조치를 요구하는 
별도의 전용 모드로 콘텐츠를 제시하는 설계 기법입니다.
```

기존의 플로우 혹은 상위 뷰와 연관되지 않는 독립된 작업을 하는 경우 modal 방식의 화면전환 사용한다고 문서에 제시되어있고

아이폰 기본 앱인 시계 앱의 알람 탭의 경우 + 버튼을 눌러 새로운 알람을 추가하는 작업에서 modal 방식이 사용되었습니다. (아마도 메인 화면과 독립된 작업이기 때문에)
해당 플로우와 비슷한 경우의 화면 전환이라고 생각해 의문이 생겼습니다!

1. 싱글톤 객체 의존성 주입

이전 PR에서 남겨주신 내용을 코멘트를 참고해서 init()에서 싱글톤 객체를 주입해서 객체 간의 결합도를 낮추어 보았는데요! `JuiceMaker` 구조체에서 한 방식과 같이 init 생성자의 파라미터로 객체 주입을 해주고 싶었는데, `UIViewController`를 상속받는  ViewController 에서는 init 생성자를 커스텀하니 fatal Error 가 떠서 찾아보니 스토리보드를 사용하는 경우 별도의 처리가 필요하다고 해서 이것저것 시도해보았는데 잘 안되어서,, 파라미터가 아닌 그냥 init() 함수 내에서 주입해주는 방식으로 구현해두었습니다.

사실 평소에 거의 스토리보드 없이 개발해왔어서 이 이슈를 처음 겪었는데 ,, 왜 스토리보드를 사용할 경우에만 에러가 발생하고, 해당 경우의 해결방법을 혹시 아신다면,,, 공유해주시면 감사하겠습니다,,,

- 기존에 required init? 과 함께 써준 코드

```Swift
    init(fruitStore: FruitStore = FruitStore.shared) {
        self.fruitStore = fruitStore
        super.init(nibName: nil, bundle: nil)
    }

```