### PR TITLE
쥬스자판기 [Step 3] 댄, 라마

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
-		C73DAF3B255D0CDD00020D38 /* JuiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* JuiceViewController.swift */; };
+		C73DAF3B255D0CDD00020D38 /* FruitJuiceOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* FruitJuiceOrderViewController.swift */; };
 		C73DAF3E255D0CDD00020D38 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3C255D0CDD00020D38 /* Main.storyboard */; };
 		C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3F255D0CDE00020D38 /* Assets.xcassets */; };
 		C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
@@ -24,7 +24,7 @@
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C73DAF3A255D0CDD00020D38 /* JuiceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceViewController.swift; sourceTree = "<group>"; };
+		C73DAF3A255D0CDD00020D38 /* FruitJuiceOrderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitJuiceOrderViewController.swift; sourceTree = "<group>"; };
 		C73DAF3D255D0CDD00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C73DAF3F255D0CDE00020D38 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C73DAF42255D0CDF00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -48,7 +48,7 @@
 			children = (
 				C73DAF36255D0CDD00020D38 /* AppDelegate.swift */,
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
-				C73DAF3A255D0CDD00020D38 /* JuiceViewController.swift */,
+				C73DAF3A255D0CDD00020D38 /* FruitJuiceOrderViewController.swift */,
 				22ACF2A22B27F93400F627AE /* StockViewController.swift */,
 			);
 			path = Controller;
@@ -171,7 +171,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
-				C73DAF3B255D0CDD00020D38 /* JuiceViewController.swift in Sources */,
+				C73DAF3B255D0CDD00020D38 /* FruitJuiceOrderViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		22ACF2A32B27F93400F627AE /* SupplyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22ACF2A22B27F93400F627AE /* SupplyViewController.swift */; };
+		22ACF2A32B27F93400F627AE /* StockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22ACF2A22B27F93400F627AE /* StockViewController.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
@@ -19,7 +19,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		22ACF2A22B27F93400F627AE /* SupplyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupplyViewController.swift; sourceTree = "<group>"; };
+		22ACF2A22B27F93400F627AE /* StockViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockViewController.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -49,7 +49,7 @@
 				C73DAF36255D0CDD00020D38 /* AppDelegate.swift */,
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
 				C73DAF3A255D0CDD00020D38 /* JuiceViewController.swift */,
-				22ACF2A22B27F93400F627AE /* SupplyViewController.swift */,
+				22ACF2A22B27F93400F627AE /* StockViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -175,7 +175,7 @@
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,
-				22ACF2A32B27F93400F627AE /* SupplyViewController.swift in Sources */,
+				22ACF2A32B27F93400F627AE /* StockViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JuiceMaker/JuiceMaker/Controller/FruitJuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/FruitJuiceOrderViewController.swift
@@ -23,10 +23,15 @@ class FruitJuiceOrderViewController: UIViewController {
     }
     
     private func presentStockViewController() {
-        let stockViewNavigationController = storyboard?.instantiateViewController(withIdentifier: "StockViewNavigationController") as! UINavigationController
-        if let stockViewController = stockViewNavigationController.viewControllers.first as? StockViewController {
-            stockViewController.delegate = self
+        guard let stockViewNavigationController = storyboard?.instantiateViewController(withIdentifier: "StockViewNavigationController") as? UINavigationController else {
+            return
         }
+        
+        guard let stockViewController = stockViewNavigationController.viewControllers.first as? StockViewController else {
+            return
+        }
+        
+        stockViewController.delegate = self
         present(stockViewNavigationController, animated: true)
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/FruitJuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/FruitJuiceOrderViewController.swift
@@ -1,12 +1,12 @@
 //
-//  JuiceMaker - JuiceViewController.swift
-//  Created by yagom. 
+//  JuiceMaker - FruitJuiceOrderViewController.swift
+//  Created by yagom.
 //  Copyright © yagom academy. All rights reserved.
 // 
 
 import UIKit
 
-class JuiceViewController: UIViewController {
+class FruitJuiceOrderViewController: UIViewController {
     
     @IBOutlet private weak var strawberryCountLabel: UILabel!
     @IBOutlet private weak var bananaCountLabel: UILabel!
@@ -102,7 +102,7 @@ class JuiceViewController: UIViewController {
     }
 }
 
-extension JuiceViewController: StockViewControllerDelegate {
+extension FruitJuiceOrderViewController: StockViewControllerDelegate {
     func stockViewWillDisappear() {
         reloadFruitsCount()
     }

--- a/JuiceMaker/JuiceMaker/Controller/FruitJuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/FruitJuiceOrderViewController.swift
@@ -2,7 +2,7 @@
 //  JuiceMaker - FruitJuiceOrderViewController.swift
 //  Created by yagom.
 //  Copyright © yagom academy. All rights reserved.
-// 
+//
 
 import UIKit
 
@@ -22,6 +22,65 @@ class FruitJuiceOrderViewController: UIViewController {
         reloadFruitsCount()
     }
     
+    private func presentStockViewController() {
+        let stockViewNavigationController = storyboard?.instantiateViewController(withIdentifier: "StockViewNavigationController") as! UINavigationController
+        if let stockViewController = stockViewNavigationController.viewControllers.first as? StockViewController {
+            stockViewController.delegate = self
+        }
+        present(stockViewNavigationController, animated: true)
+    }
+}
+
+extension FruitJuiceOrderViewController {
+    private func orderJuice(menu: JuiceMaker.Menu) {
+        do {
+            try juiceMaker.makeJuice(menu: menu)
+            reloadFruitsCount()
+            alertJuiceServed(menu: menu)
+        } catch {
+            print(error)
+            alertInsufficientStock()
+        }
+    }
+    
+    private func reloadFruitsCount() {
+        strawberryCountLabel.text = String(fruitStore.storage[.strawberry] ?? 0)
+        bananaCountLabel.text = String(fruitStore.storage[.banana] ?? 0)
+        pineappleCountLabel.text = String(fruitStore.storage[.pineapple] ?? 0)
+        kiwiCountLabel.text = String(fruitStore.storage[.kiwi] ?? 0)
+        mangoCountLabel.text = String(fruitStore.storage[.mango] ?? 0)
+    }
+}
+
+extension FruitJuiceOrderViewController {
+    private func alertJuiceServed(menu: JuiceMaker.Menu) {
+        let alert = UIAlertController(title: "", message: "\(menu) 나왔습니다! 맛있게 드세요!", preferredStyle: .alert)
+        let juiceServedAlertAction = UIAlertAction(title: "쥬스 수령", style: .default)
+        
+        alert.addAction(juiceServedAlertAction)
+        present(alert, animated: true)
+    }
+    
+    private func alertInsufficientStock() {
+        let alert = UIAlertController(title: "", message: "재료가 모자라요. 재고를 수정할까요?", preferredStyle: .alert)
+        let yesAlertAction = UIAlertAction(title: "예", style: .default, handler: { _ in
+            self.presentStockViewController()
+        })
+        let noAlertAction = UIAlertAction(title: "아니오", style: .cancel)
+        
+        alert.addAction(yesAlertAction)
+        alert.addAction(noAlertAction)
+        present(alert, animated: true)
+    }
+}
+
+extension FruitJuiceOrderViewController: StockViewControllerDelegate {
+    func stockViewWillDisappear() {
+        reloadFruitsCount()
+    }
+}
+
+extension FruitJuiceOrderViewController {
     @IBAction private func updateStockButtonTapped(_ sender: UIBarButtonItem) {
         presentStockViewController()
     }
@@ -52,58 +111,5 @@ class FruitJuiceOrderViewController: UIViewController {
     
     @IBAction private func mangoKiwiJuiceOrderButtonTapped(_ sender: UIButton) {
         orderJuice(menu: .망고키위쥬스)
-    }
-    
-    private func orderJuice(menu: JuiceMaker.Menu) {
-        do {
-            try juiceMaker.makeJuice(menu: menu)
-            alertJuiceServed(menu: menu)
-            reloadFruitsCount()
-        } catch {
-            print(error)
-            alertInsufficientStock()
-        }
-    }
-    
-    private func presentStockViewController() {
-        let stockViewNavigationController = storyboard?.instantiateViewController(withIdentifier: "StockViewNavigationController") as! UINavigationController
-        if let stockViewController = stockViewNavigationController.viewControllers.first as? StockViewController {
-            stockViewController.delegate = self
-        }
-        present(stockViewNavigationController, animated: true)
-    }
-    
-    private func alertJuiceServed(menu: JuiceMaker.Menu) {
-        let alert = UIAlertController(title: "", message: "\(menu) 나왔습니다! 맛있게 드세요!", preferredStyle: .alert)
-        let juiceServedAlertAction = UIAlertAction(title: "쥬스 수령", style: .default)
-        
-        alert.addAction(juiceServedAlertAction)
-        present(alert, animated: true)
-    }
-    
-    private func alertInsufficientStock() {
-        let alert = UIAlertController(title: "", message: "재료가 모자라요. 재고를 수정할까요?", preferredStyle: .alert)
-        let yesAlertAction = UIAlertAction(title: "예", style: .default, handler: { _ in
-            self.presentStockViewController()
-        })
-        let noAlertAction = UIAlertAction(title: "아니오", style: .cancel)
-        
-        alert.addAction(yesAlertAction)
-        alert.addAction(noAlertAction)
-        present(alert, animated: true)
-    }
-    
-    private func reloadFruitsCount() {
-        strawberryCountLabel.text = String(fruitStore.storage[.strawberry] ?? 0)
-        bananaCountLabel.text = String(fruitStore.storage[.banana] ?? 0)
-        pineappleCountLabel.text = String(fruitStore.storage[.pineapple] ?? 0)
-        kiwiCountLabel.text = String(fruitStore.storage[.kiwi] ?? 0)
-        mangoCountLabel.text = String(fruitStore.storage[.mango] ?? 0)
-    }
-}
-
-extension FruitJuiceOrderViewController: StockViewControllerDelegate {
-    func stockViewWillDisappear() {
-        reloadFruitsCount()
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/FruitJuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/FruitJuiceOrderViewController.swift
@@ -94,11 +94,11 @@ class FruitJuiceOrderViewController: UIViewController {
     }
     
     private func reloadFruitsCount() {
-        strawberryCountLabel.text = String(describing: fruitStore.storage[.strawberry] ?? 0)
-        bananaCountLabel.text = String(describing: fruitStore.storage[.banana] ?? 0)
-        pineappleCountLabel.text = String(describing: fruitStore.storage[.pineapple] ?? 0)
-        kiwiCountLabel.text = String(describing: fruitStore.storage[.kiwi] ?? 0)
-        mangoCountLabel.text = String(describing: fruitStore.storage[.mango] ?? 0)
+        strawberryCountLabel.text = String(fruitStore.storage[.strawberry] ?? 0)
+        bananaCountLabel.text = String(fruitStore.storage[.banana] ?? 0)
+        pineappleCountLabel.text = String(fruitStore.storage[.pineapple] ?? 0)
+        kiwiCountLabel.text = String(fruitStore.storage[.kiwi] ?? 0)
+        mangoCountLabel.text = String(fruitStore.storage[.mango] ?? 0)
     }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
@@ -1,5 +1,5 @@
 //
-//  JuiceMaker - ViewController.swift
+//  JuiceMaker - JuiceViewController.swift
 //  Created by yagom. 
 //  Copyright © yagom academy. All rights reserved.
 // 
@@ -22,7 +22,7 @@ class JuiceViewController: UIViewController {
         reloadFruitsCount()
     }
     
-    @IBAction func updatingStockButtonTapped(_ sender: UIBarButtonItem) {
+    @IBAction private func updatingStockButtonTapped(_ sender: UIBarButtonItem) {
         showStockViewModal()
     }
     
@@ -65,14 +65,6 @@ class JuiceViewController: UIViewController {
         }
     }
     
-    private func reloadFruitsCount() {
-        strawberryCountLabel.text = String(describing: fruitStore.storage[.strawberry] ?? 0)
-        bananaCountLabel.text = String(describing: fruitStore.storage[.banana] ?? 0)
-        pineappleCountLabel.text = String(describing: fruitStore.storage[.pineapple] ?? 0)
-        kiwiCountLabel.text = String(describing: fruitStore.storage[.kiwi] ?? 0)
-        mangoCountLabel.text = String(describing: fruitStore.storage[.mango] ?? 0)
-    }
-    
     private func showStockViewModal() {
         let stockViewNavigationController = storyboard?.instantiateViewController(withIdentifier: "StockViewNavigationController") as! UINavigationController
         if let stockViewController = stockViewNavigationController.viewControllers.first as? StockViewController {
@@ -99,6 +91,14 @@ class JuiceViewController: UIViewController {
         alert.addAction(yesAlertAction)
         alert.addAction(noAlertAction)
         present(alert, animated: true)
+    }
+    
+    private func reloadFruitsCount() {
+        strawberryCountLabel.text = String(describing: fruitStore.storage[.strawberry] ?? 0)
+        bananaCountLabel.text = String(describing: fruitStore.storage[.banana] ?? 0)
+        pineappleCountLabel.text = String(describing: fruitStore.storage[.pineapple] ?? 0)
+        kiwiCountLabel.text = String(describing: fruitStore.storage[.kiwi] ?? 0)
+        mangoCountLabel.text = String(describing: fruitStore.storage[.mango] ?? 0)
     }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
@@ -75,6 +75,9 @@ class JuiceViewController: UIViewController {
     
     private func showNavigationView() {
         let supplyViewNavigationController = storyboard?.instantiateViewController(withIdentifier: "SupplyViewNavigationController") as! UINavigationController
+        if let supplyViewController = supplyViewNavigationController.viewControllers.first as? SupplyViewController {
+            supplyViewController.delegate = self
+        }
         present(supplyViewNavigationController, animated: true)
     }
     
@@ -96,5 +99,11 @@ class JuiceViewController: UIViewController {
         alert.addAction(yesAlertAction)
         alert.addAction(noAlertAction)
         present(alert, animated: true)
+    }
+}
+
+extension JuiceViewController: SupplyViewControllerDelegate {
+    func supplyViewControllerDidExit() {
+        reloadFruitsCount()
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
@@ -23,7 +23,7 @@ class JuiceViewController: UIViewController {
         reloadFruitsCount()
     }
     
-    @IBAction private func updatingStockButtonTapped(_ sender: UIButton) {
+    @IBAction func updatingStockButtonTapped(_ sender: UIBarButtonItem) {
         showNavigationView()
     }
     
@@ -67,11 +67,11 @@ class JuiceViewController: UIViewController {
     }
     
     private func reloadFruitsCount() {
-        strawberryCountLabel.text = String(describing: fruitStore.storage[.strawberry])
-        bananaCountLabel.text = String(describing: fruitStore.storage[.banana])
-        pineappleCountLabel.text = String(describing: fruitStore.storage[.pineapple])
-        kiwiCountLabel.text = String(describing: fruitStore.storage[.kiwi])
-        mangoCountLabel.text = String(describing: fruitStore.storage[.mango])
+        strawberryCountLabel.text = String(describing: fruitStore.storage[.strawberry] ?? 0)
+        bananaCountLabel.text = String(describing: fruitStore.storage[.banana] ?? 0)
+        pineappleCountLabel.text = String(describing: fruitStore.storage[.pineapple] ?? 0)
+        kiwiCountLabel.text = String(describing: fruitStore.storage[.kiwi] ?? 0)
+        mangoCountLabel.text = String(describing: fruitStore.storage[.mango] ?? 0)
     }
     
     private func showNavigationView() {

--- a/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
@@ -23,7 +23,7 @@ class JuiceViewController: UIViewController {
     }
     
     @IBAction func updatingStockButtonTapped(_ sender: UIBarButtonItem) {
-        showNavigationView()
+        showStockViewModal()
     }
     
     @IBAction private func strawberryJuiceOrderButtonTapped(_ sender: UIButton) {
@@ -73,12 +73,12 @@ class JuiceViewController: UIViewController {
         mangoCountLabel.text = String(describing: fruitStore.storage[.mango] ?? 0)
     }
     
-    private func showNavigationView() {
-        let supplyViewNavigationController = storyboard?.instantiateViewController(withIdentifier: "SupplyViewNavigationController") as! UINavigationController
-        if let supplyViewController = supplyViewNavigationController.viewControllers.first as? SupplyViewController {
-            supplyViewController.delegate = self
+    private func showStockViewModal() {
+        let stockViewNavigationController = storyboard?.instantiateViewController(withIdentifier: "StockViewNavigationController") as! UINavigationController
+        if let stockViewController = stockViewNavigationController.viewControllers.first as? StockViewController {
+            stockViewController.delegate = self
         }
-        present(supplyViewNavigationController, animated: true)
+        present(stockViewNavigationController, animated: true)
     }
     
     private func alertJuiceServed(menu: JuiceMaker.Menu) {
@@ -92,7 +92,7 @@ class JuiceViewController: UIViewController {
     private func alertInsufficientStock() {
         let alert = UIAlertController(title: "", message: "재료가 모자라요. 재고를 수정할까요?", preferredStyle: .alert)
         let yesAlertAction = UIAlertAction(title: "예", style: .default, handler: { _ in
-            self.showNavigationView()
+            self.showStockViewModal()
         })
         let noAlertAction = UIAlertAction(title: "아니오", style: .cancel)
         
@@ -102,8 +102,8 @@ class JuiceViewController: UIViewController {
     }
 }
 
-extension JuiceViewController: SupplyViewControllerDelegate {
-    func supplyViewControllerDidExit() {
+extension JuiceViewController: StockViewControllerDelegate {
+    func stockViewControllerDidExit() {
         reloadFruitsCount()
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
@@ -22,7 +22,7 @@ class JuiceViewController: UIViewController {
         reloadFruitsCount()
     }
     
-    @IBAction private func updatingStockButtonTapped(_ sender: UIBarButtonItem) {
+    @IBAction private func updateStockButtonTapped(_ sender: UIBarButtonItem) {
         showStockViewModal()
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
@@ -103,7 +103,7 @@ class JuiceViewController: UIViewController {
 }
 
 extension JuiceViewController: StockViewControllerDelegate {
-    func stockViewControllerWillDisappear() {
+    func stockViewWillDisappear() {
         reloadFruitsCount()
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
@@ -103,7 +103,7 @@ class JuiceViewController: UIViewController {
 }
 
 extension JuiceViewController: StockViewControllerDelegate {
-    func stockViewControllerDidExit() {
+    func stockViewControllerWillDisappear() {
         reloadFruitsCount()
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
@@ -23,49 +23,36 @@ class JuiceViewController: UIViewController {
         reloadFruitsCount()
     }
     
-    @IBAction private func adjustingStockButtonTapped(_ sender: UIButton) {
+    @IBAction private func updatingStockButtonTapped(_ sender: UIButton) {
         showNavigationView()
     }
     
-    @IBAction private func strawberryJuiceButtonTapped(_ sender: UIButton) {
+    @IBAction private func strawberryJuiceOrderButtonTapped(_ sender: UIButton) {
         orderJuice(menu: .딸기쥬스)
     }
     
-    @IBAction private func bananaJuiceButtonTapped(_ sender: UIButton) {
+    @IBAction private func bananaJuiceOrderButtonTapped(_ sender: UIButton) {
         orderJuice(menu: .바나나쥬스)
     }
     
-    @IBAction private func pineappleJuiceButtonTapped(_ sender: UIButton) {
+    @IBAction private func pineappleJuiceOrderButtonTapped(_ sender: UIButton) {
         orderJuice(menu: .파인애플쥬스)
     }
     
-    @IBAction private func kiwiJuiceButtonTapped(_ sender: UIButton) {
+    @IBAction private func kiwiJuiceOrderButtonTapped(_ sender: UIButton) {
         orderJuice(menu: .키위쥬스)
     }
     
-    @IBAction private func mangoJuiceButtonTapped(_ sender: UIButton) {
+    @IBAction private func mangoJuiceOrderButtonTapped(_ sender: UIButton) {
         orderJuice(menu: .망고쥬스)
     }
     
-    @IBAction private func strawberryBananaJuiceButtonTapped(_ sender: UIButton) {
+    @IBAction private func strawberryBananaJuiceOrderButtonTapped(_ sender: UIButton) {
         orderJuice(menu: .딸바쥬스)
     }
     
-    @IBAction private func mangoKiwiJuiceButtonTapped(_ sender: UIButton) {
+    @IBAction private func mangoKiwiJuiceOrderButtonTapped(_ sender: UIButton) {
         orderJuice(menu: .망고키위쥬스)
-    }
-    
-    private func reloadFruitsCount() {
-        strawberryCountLabel.text = fruitStore.storage[.strawberry]?.description
-        bananaCountLabel.text = fruitStore.storage[.banana]?.description
-        pineappleCountLabel.text = fruitStore.storage[.pineapple]?.description
-        kiwiCountLabel.text = fruitStore.storage[.kiwi]?.description
-        mangoCountLabel.text = fruitStore.storage[.mango]?.description
-    }
-    
-    private func showNavigationView() {
-        let supplyViewController = storyboard?.instantiateViewController(withIdentifier: "SupplyViewController") as! SupplyViewController
-        navigationController?.pushViewController(supplyViewController, animated: true)
     }
     
     private func orderJuice(menu: JuiceMaker.Menu) {
@@ -77,6 +64,19 @@ class JuiceViewController: UIViewController {
             print(error)
             alertInsufficientStock()
         }
+    }
+    
+    private func reloadFruitsCount() {
+        strawberryCountLabel.text = String(describing: fruitStore.storage[.strawberry])
+        bananaCountLabel.text = String(describing: fruitStore.storage[.banana])
+        pineappleCountLabel.text = String(describing: fruitStore.storage[.pineapple])
+        kiwiCountLabel.text = String(describing: fruitStore.storage[.kiwi])
+        mangoCountLabel.text = String(describing: fruitStore.storage[.mango])
+    }
+    
+    private func showNavigationView() {
+        let supplyViewController = storyboard?.instantiateViewController(withIdentifier: "SupplyViewController") as! SupplyViewController
+        navigationController?.pushViewController(supplyViewController, animated: true)
     }
     
     private func alertJuiceServed(menu: JuiceMaker.Menu) {

--- a/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
@@ -23,7 +23,7 @@ class JuiceViewController: UIViewController {
     }
     
     @IBAction private func updateStockButtonTapped(_ sender: UIBarButtonItem) {
-        showStockViewModal()
+        presentStockViewController()
     }
     
     @IBAction private func strawberryJuiceOrderButtonTapped(_ sender: UIButton) {
@@ -65,7 +65,7 @@ class JuiceViewController: UIViewController {
         }
     }
     
-    private func showStockViewModal() {
+    private func presentStockViewController() {
         let stockViewNavigationController = storyboard?.instantiateViewController(withIdentifier: "StockViewNavigationController") as! UINavigationController
         if let stockViewController = stockViewNavigationController.viewControllers.first as? StockViewController {
             stockViewController.delegate = self
@@ -84,7 +84,7 @@ class JuiceViewController: UIViewController {
     private func alertInsufficientStock() {
         let alert = UIAlertController(title: "", message: "재료가 모자라요. 재고를 수정할까요?", preferredStyle: .alert)
         let yesAlertAction = UIAlertAction(title: "예", style: .default, handler: { _ in
-            self.showStockViewModal()
+            self.presentStockViewController()
         })
         let noAlertAction = UIAlertAction(title: "아니오", style: .cancel)
         

--- a/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
@@ -74,8 +74,8 @@ class JuiceViewController: UIViewController {
     }
     
     private func showNavigationView() {
-        let supplyViewController = storyboard?.instantiateViewController(withIdentifier: "SupplyViewController") as! SupplyViewController
-        navigationController?.pushViewController(supplyViewController, animated: true)
+        let supplyViewNavigationController = storyboard?.instantiateViewController(withIdentifier: "SupplyViewNavigationController") as! UINavigationController
+        present(supplyViewNavigationController, animated: true)
     }
     
     private func alertJuiceServed(menu: JuiceMaker.Menu) {

--- a/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceViewController.swift
@@ -16,10 +16,9 @@ class JuiceViewController: UIViewController {
     
     private let juiceMaker = JuiceMaker()
     private let fruitStore = FruitStore.shared
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
         
+    override func viewIsAppearing(_ animated: Bool) {
+        super.viewIsAppearing(animated)
         reloadFruitsCount()
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -30,8 +30,12 @@ class StockViewController: UIViewController {
         reloadFruitsCount()
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        delegate?.stockViewControllerWillDisappear()
+    }
+    
     @IBAction private func closeButtonTapped(_ sender: UIBarButtonItem) {
-        delegate?.stockViewControllerDidExit()
         presentingViewController?.dismiss(animated: true)
     }
     
@@ -78,5 +82,5 @@ class StockViewController: UIViewController {
 }
 
 protocol StockViewControllerDelegate: AnyObject {
-    func stockViewControllerDidExit()
+    func stockViewControllerWillDisappear()
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -72,11 +72,11 @@ class StockViewController: UIViewController {
     }
     
     private func reloadFruitsCount() {
-        strawberryCountLabel.text = String(describing: fruitStore.storage[.strawberry] ?? 0)
-        bananaCountLabel.text = String(describing: fruitStore.storage[.banana] ?? 0)
-        pineappleCountLabel.text = String(describing: fruitStore.storage[.pineapple] ?? 0)
-        kiwiCountLabel.text = String(describing: fruitStore.storage[.kiwi] ?? 0)
-        mangoCountLabel.text = String(describing: fruitStore.storage[.mango] ?? 0)
+        strawberryCountLabel.text = String(fruitStore.storage[.strawberry] ?? 0)
+        bananaCountLabel.text = String(fruitStore.storage[.banana] ?? 0)
+        pineappleCountLabel.text = String(fruitStore.storage[.pineapple] ?? 0)
+        kiwiCountLabel.text = String(fruitStore.storage[.kiwi] ?? 0)
+        mangoCountLabel.text = String(fruitStore.storage[.mango] ?? 0)
     }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -36,28 +36,27 @@ class StockViewController: UIViewController {
     }
     
     @IBAction private func strawberryStepperTapped(_ sender: UIStepper) {
-        updateStock(fruit: .strawberry, sender: sender)
+        updateStock(fruit: .strawberry, amount: Int(sender.value))
     }
     
     @IBAction private func bananaStepperTapped(_ sender: UIStepper) {
-        updateStock(fruit: .banana, sender: sender)
+        updateStock(fruit: .banana, amount: Int(sender.value))
     }
     
     @IBAction private func pineappleStepperTapped(_ sender: UIStepper) {
-        updateStock(fruit: .pineapple, sender: sender)
+        updateStock(fruit: .pineapple, amount: Int(sender.value))
     }
     
     @IBAction private func kiwiStepperTapped(_ sender: UIStepper) {
-        updateStock(fruit: .kiwi, sender: sender)
+        updateStock(fruit: .kiwi, amount: Int(sender.value))
     }
     
     @IBAction private func mangoStepperTapped(_ sender: UIStepper) {
-        updateStock(fruit: .mango, sender: sender)
+        updateStock(fruit: .mango, amount: Int(sender.value))
     }
     
-    private func updateStock(fruit: FruitStore.Fruit, sender: UIStepper) {
-        let stepperValue = Int(sender.value)
-        fruitStore.updateStock(fruit: fruit, amount: stepperValue)
+    private func updateStock(fruit: FruitStore.Fruit, amount: Int) {
+        fruitStore.updateStock(fruit: fruit, amount: amount)
         reloadFruitsCount()
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-class SupplyViewController: UIViewController {
+class StockViewController: UIViewController {
     
     @IBOutlet private weak var strawberryCountLabel: UILabel!
     @IBOutlet private weak var bananaCountLabel: UILabel!
@@ -20,7 +20,7 @@ class SupplyViewController: UIViewController {
     @IBOutlet weak var kiwiStepper: UIStepper!
     @IBOutlet weak var mangoStepper: UIStepper!
     
-    weak var delegate: SupplyViewControllerDelegate?
+    weak var delegate: StockViewControllerDelegate?
     private let fruitStore = FruitStore.shared
     
     override func viewIsAppearing(_ animated: Bool) {
@@ -31,7 +31,7 @@ class SupplyViewController: UIViewController {
     }
     
     @IBAction func closeButtonTapped(_ sender: UIBarButtonItem) {
-        delegate?.supplyViewControllerDidExit()
+        delegate?.stockViewControllerDidExit()
         presentingViewController?.dismiss(animated: true)
     }
     
@@ -78,6 +78,6 @@ class SupplyViewController: UIViewController {
     }
 }
 
-protocol SupplyViewControllerDelegate: AnyObject {
-    func supplyViewControllerDidExit()
+protocol StockViewControllerDelegate: AnyObject {
+    func stockViewControllerDidExit()
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -26,7 +26,7 @@ class StockViewController: UIViewController {
     override func viewIsAppearing(_ animated: Bool) {
         super.viewIsAppearing(animated)
         
-        setInitialStepperValue()
+        setInitialStepperValues()
         reloadFruitsCount()
     }
     
@@ -64,7 +64,7 @@ class StockViewController: UIViewController {
         reloadFruitsCount()
     }
     
-    private func setInitialStepperValue() {
+    private func setInitialStepperValues() {
         strawberryStepper.value = Double(fruitStore.storage[.strawberry] ?? 0)
         bananaStepper.value = Double(fruitStore.storage[.banana] ?? 0)
         pineappleStepper.value = Double(fruitStore.storage[.pineapple] ?? 0)

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -6,6 +6,10 @@
 
 import UIKit
 
+protocol StockViewControllerDelegate: AnyObject {
+    func stockViewWillDisappear()
+}
+
 class StockViewController: UIViewController {
     
     @IBOutlet private weak var strawberryCountLabel: UILabel!
@@ -33,7 +37,32 @@ class StockViewController: UIViewController {
         super.viewWillDisappear(animated)
         delegate?.stockViewWillDisappear()
     }
+}
+
+extension StockViewController {
+    private func updateStock(fruit: FruitStore.Fruit, amount: Int) {
+        fruitStore.updateStock(fruit: fruit, amount: amount)
+        reloadFruitsCount()
+    }
     
+    private func reloadFruitsCount() {
+        strawberryCountLabel.text = String(fruitStore.storage[.strawberry] ?? 0)
+        bananaCountLabel.text = String(fruitStore.storage[.banana] ?? 0)
+        pineappleCountLabel.text = String(fruitStore.storage[.pineapple] ?? 0)
+        kiwiCountLabel.text = String(fruitStore.storage[.kiwi] ?? 0)
+        mangoCountLabel.text = String(fruitStore.storage[.mango] ?? 0)
+    }
+    
+    private func setInitialStepperValues() {
+        strawberryStepper.value = Double(fruitStore.storage[.strawberry] ?? 0)
+        bananaStepper.value = Double(fruitStore.storage[.banana] ?? 0)
+        pineappleStepper.value = Double(fruitStore.storage[.pineapple] ?? 0)
+        kiwiStepper.value = Double(fruitStore.storage[.kiwi] ?? 0)
+        mangoStepper.value = Double(fruitStore.storage[.mango] ?? 0)
+    }
+}
+
+extension StockViewController {
     @IBAction private func closeButtonTapped(_ sender: UIBarButtonItem) {
         presentingViewController?.dismiss(animated: true)
     }
@@ -57,29 +86,4 @@ class StockViewController: UIViewController {
     @IBAction private func mangoStepperTapped(_ sender: UIStepper) {
         updateStock(fruit: .mango, amount: Int(sender.value))
     }
-    
-    private func updateStock(fruit: FruitStore.Fruit, amount: Int) {
-        fruitStore.updateStock(fruit: fruit, amount: amount)
-        reloadFruitsCount()
-    }
-    
-    private func setInitialStepperValues() {
-        strawberryStepper.value = Double(fruitStore.storage[.strawberry] ?? 0)
-        bananaStepper.value = Double(fruitStore.storage[.banana] ?? 0)
-        pineappleStepper.value = Double(fruitStore.storage[.pineapple] ?? 0)
-        kiwiStepper.value = Double(fruitStore.storage[.kiwi] ?? 0)
-        mangoStepper.value = Double(fruitStore.storage[.mango] ?? 0)
-    }
-    
-    private func reloadFruitsCount() {
-        strawberryCountLabel.text = String(fruitStore.storage[.strawberry] ?? 0)
-        bananaCountLabel.text = String(fruitStore.storage[.banana] ?? 0)
-        pineappleCountLabel.text = String(fruitStore.storage[.pineapple] ?? 0)
-        kiwiCountLabel.text = String(fruitStore.storage[.kiwi] ?? 0)
-        mangoCountLabel.text = String(fruitStore.storage[.mango] ?? 0)
-    }
-}
-
-protocol StockViewControllerDelegate: AnyObject {
-    func stockViewWillDisappear()
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -25,14 +25,13 @@ class StockViewController: UIViewController {
     
     override func viewIsAppearing(_ animated: Bool) {
         super.viewIsAppearing(animated)
-        
         setInitialStepperValues()
         reloadFruitsCount()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        delegate?.stockViewControllerWillDisappear()
+        delegate?.stockViewWillDisappear()
     }
     
     @IBAction private func closeButtonTapped(_ sender: UIBarButtonItem) {
@@ -82,5 +81,5 @@ class StockViewController: UIViewController {
 }
 
 protocol StockViewControllerDelegate: AnyObject {
-    func stockViewControllerWillDisappear()
+    func stockViewWillDisappear()
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -1,5 +1,5 @@
 //
-//  SupplyViewController.swift
+//  StockViewController.swift
 //  JuiceMaker
 //
 //
@@ -14,11 +14,11 @@ class StockViewController: UIViewController {
     @IBOutlet private weak var kiwiCountLabel: UILabel!
     @IBOutlet private weak var mangoCountLabel: UILabel!
     
-    @IBOutlet weak var strawberryStepper: UIStepper!
-    @IBOutlet weak var bananaStepper: UIStepper!
-    @IBOutlet weak var pineappleStepper: UIStepper!
-    @IBOutlet weak var kiwiStepper: UIStepper!
-    @IBOutlet weak var mangoStepper: UIStepper!
+    @IBOutlet private weak var strawberryStepper: UIStepper!
+    @IBOutlet private weak var bananaStepper: UIStepper!
+    @IBOutlet private weak var pineappleStepper: UIStepper!
+    @IBOutlet private weak var kiwiStepper: UIStepper!
+    @IBOutlet private weak var mangoStepper: UIStepper!
     
     weak var delegate: StockViewControllerDelegate?
     private let fruitStore = FruitStore.shared
@@ -30,28 +30,28 @@ class StockViewController: UIViewController {
         reloadFruitsCount()
     }
     
-    @IBAction func closeButtonTapped(_ sender: UIBarButtonItem) {
+    @IBAction private func closeButtonTapped(_ sender: UIBarButtonItem) {
         delegate?.stockViewControllerDidExit()
         presentingViewController?.dismiss(animated: true)
     }
     
-    @IBAction func strawberryStepperTapped(_ sender: UIStepper) {
+    @IBAction private func strawberryStepperTapped(_ sender: UIStepper) {
         updateStock(fruit: .strawberry, sender: sender)
     }
     
-    @IBAction func bananaStepperTapped(_ sender: UIStepper) {
+    @IBAction private func bananaStepperTapped(_ sender: UIStepper) {
         updateStock(fruit: .banana, sender: sender)
     }
     
-    @IBAction func pineappleStepperTapped(_ sender: UIStepper) {
+    @IBAction private func pineappleStepperTapped(_ sender: UIStepper) {
         updateStock(fruit: .pineapple, sender: sender)
     }
     
-    @IBAction func kiwiStepperTapped(_ sender: UIStepper) {
+    @IBAction private func kiwiStepperTapped(_ sender: UIStepper) {
         updateStock(fruit: .kiwi, sender: sender)
     }
     
-    @IBAction func mangoStepperTapped(_ sender: UIStepper) {
+    @IBAction private func mangoStepperTapped(_ sender: UIStepper) {
         updateStock(fruit: .mango, sender: sender)
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/SupplyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/SupplyViewController.swift
@@ -8,11 +8,11 @@ import UIKit
 
 class SupplyViewController: UIViewController {
     
-    @IBOutlet private weak var strawberryCount: UILabel!
-    @IBOutlet private weak var bananaCount: UILabel!
-    @IBOutlet private weak var pineappleCount: UILabel!
-    @IBOutlet private weak var kiwiCount: UILabel!
-    @IBOutlet private weak var mangoCount: UILabel!
+    @IBOutlet private weak var strawberryCountLabel: UILabel!
+    @IBOutlet private weak var bananaCountLabel: UILabel!
+    @IBOutlet private weak var pineappleCountLabel: UILabel!
+    @IBOutlet private weak var kiwiCountLabel: UILabel!
+    @IBOutlet private weak var mangoCountLabel: UILabel!
     
     private let fruitStore = FruitStore.shared
 
@@ -23,11 +23,11 @@ class SupplyViewController: UIViewController {
     }
     
     private func reloadFruitsCount() {
-        strawberryCount.text = fruitStore.storage[.strawberry]?.description
-        bananaCount.text = fruitStore.storage[.banana]?.description
-        pineappleCount.text = fruitStore.storage[.pineapple]?.description
-        kiwiCount.text = fruitStore.storage[.kiwi]?.description
-        mangoCount.text = fruitStore.storage[.mango]?.description
+        strawberryCountLabel.text = String(describing: fruitStore.storage[.strawberry])
+        bananaCountLabel.text = String(describing: fruitStore.storage[.banana])
+        pineappleCountLabel.text = String(describing: fruitStore.storage[.pineapple])
+        kiwiCountLabel.text = String(describing: fruitStore.storage[.kiwi])
+        mangoCountLabel.text = String(describing: fruitStore.storage[.mango])
     }
 
 

--- a/JuiceMaker/JuiceMaker/Controller/SupplyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/SupplyViewController.swift
@@ -29,6 +29,10 @@ class SupplyViewController: UIViewController {
         reloadFruitsCount()
     }
     
+    @IBAction func closeButtonTapped(_ sender: UIBarButtonItem) {
+        
+    }
+    
     @IBAction func strawberryStepperTapped(_ sender: UIStepper) {
         updateStock(fruit: .strawberry, sender: sender)
     }

--- a/JuiceMaker/JuiceMaker/Controller/SupplyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/SupplyViewController.swift
@@ -23,11 +23,11 @@ class SupplyViewController: UIViewController {
     }
     
     private func reloadFruitsCount() {
-        strawberryCountLabel.text = String(describing: fruitStore.storage[.strawberry])
-        bananaCountLabel.text = String(describing: fruitStore.storage[.banana])
-        pineappleCountLabel.text = String(describing: fruitStore.storage[.pineapple])
-        kiwiCountLabel.text = String(describing: fruitStore.storage[.kiwi])
-        mangoCountLabel.text = String(describing: fruitStore.storage[.mango])
+        strawberryCountLabel.text = String(describing: fruitStore.storage[.strawberry] ?? 0)
+        bananaCountLabel.text = String(describing: fruitStore.storage[.banana] ?? 0)
+        pineappleCountLabel.text = String(describing: fruitStore.storage[.pineapple] ?? 0)
+        kiwiCountLabel.text = String(describing: fruitStore.storage[.kiwi] ?? 0)
+        mangoCountLabel.text = String(describing: fruitStore.storage[.mango] ?? 0)
     }
 
 

--- a/JuiceMaker/JuiceMaker/Controller/SupplyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/SupplyViewController.swift
@@ -25,7 +25,7 @@ class SupplyViewController: UIViewController {
     override func viewIsAppearing(_ animated: Bool) {
         super.viewIsAppearing(animated)
         
-        setInitStepperValue()
+        setInitialStepperValue()
         reloadFruitsCount()
     }
     
@@ -49,7 +49,13 @@ class SupplyViewController: UIViewController {
         updateStock(fruit: .mango, sender: sender)
     }
     
-    private func setInitStepperValue() {
+    private func updateStock(fruit: FruitStore.Fruit, sender: UIStepper) {
+        let stepperValue = Int(sender.value)
+        fruitStore.updateStock(fruit: fruit, amount: stepperValue)
+        reloadFruitsCount()
+    }
+    
+    private func setInitialStepperValue() {
         strawberryStepper.value = Double(fruitStore.storage[.strawberry] ?? 0)
         bananaStepper.value = Double(fruitStore.storage[.banana] ?? 0)
         pineappleStepper.value = Double(fruitStore.storage[.pineapple] ?? 0)
@@ -63,13 +69,5 @@ class SupplyViewController: UIViewController {
         pineappleCountLabel.text = String(describing: fruitStore.storage[.pineapple] ?? 0)
         kiwiCountLabel.text = String(describing: fruitStore.storage[.kiwi] ?? 0)
         mangoCountLabel.text = String(describing: fruitStore.storage[.mango] ?? 0)
-    }
-    
-    private func updateStock(fruit: FruitStore.Fruit, sender: UIStepper) {
-        let stepperValue = Int(sender.value)
-        let currentFruitStock = fruitStore.storage[fruit] ?? 0
-        let adjustmentValue = stepperValue - currentFruitStock
-        try? fruitStore.updateStock(fruit: fruit, amount: adjustmentValue)
-        reloadFruitsCount()
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/SupplyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/SupplyViewController.swift
@@ -15,10 +15,9 @@ class SupplyViewController: UIViewController {
     @IBOutlet private weak var mangoCountLabel: UILabel!
     
     private let fruitStore = FruitStore.shared
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
+    
+    override func viewIsAppearing(_ animated: Bool) {
+        super.viewIsAppearing(animated)
         reloadFruitsCount()
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/SupplyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/SupplyViewController.swift
@@ -30,23 +30,23 @@ class SupplyViewController: UIViewController {
     }
     
     @IBAction func strawberryStepperTapped(_ sender: UIStepper) {
-        
+        updateStock(fruit: .strawberry, sender: sender)
     }
     
     @IBAction func bananaStepperTapped(_ sender: UIStepper) {
-        
+        updateStock(fruit: .banana, sender: sender)
     }
     
     @IBAction func pineappleStepperTapped(_ sender: UIStepper) {
-        
+        updateStock(fruit: .pineapple, sender: sender)
     }
     
     @IBAction func kiwiStepperTapped(_ sender: UIStepper) {
-        
+        updateStock(fruit: .kiwi, sender: sender)
     }
     
     @IBAction func mangoStepperTapped(_ sender: UIStepper) {
-        
+        updateStock(fruit: .mango, sender: sender)
     }
     
     private func setInitStepperValue() {
@@ -64,6 +64,12 @@ class SupplyViewController: UIViewController {
         kiwiCountLabel.text = String(describing: fruitStore.storage[.kiwi] ?? 0)
         mangoCountLabel.text = String(describing: fruitStore.storage[.mango] ?? 0)
     }
-
-
+    
+    private func updateStock(fruit: FruitStore.Fruit, sender: UIStepper) {
+        let stepperValue = Int(sender.value)
+        let currentFruitStock = fruitStore.storage[fruit] ?? 0
+        let adjustmentValue = stepperValue - currentFruitStock
+        try? fruitStore.updateStock(fruit: fruit, amount: adjustmentValue)
+        reloadFruitsCount()
+    }
 }

--- a/JuiceMaker/JuiceMaker/Controller/SupplyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/SupplyViewController.swift
@@ -20,6 +20,7 @@ class SupplyViewController: UIViewController {
     @IBOutlet weak var kiwiStepper: UIStepper!
     @IBOutlet weak var mangoStepper: UIStepper!
     
+    weak var delegate: SupplyViewControllerDelegate?
     private let fruitStore = FruitStore.shared
     
     override func viewIsAppearing(_ animated: Bool) {
@@ -30,6 +31,7 @@ class SupplyViewController: UIViewController {
     }
     
     @IBAction func closeButtonTapped(_ sender: UIBarButtonItem) {
+        delegate?.supplyViewControllerDidExit()
         presentingViewController?.dismiss(animated: true)
     }
     
@@ -74,4 +76,8 @@ class SupplyViewController: UIViewController {
         kiwiCountLabel.text = String(describing: fruitStore.storage[.kiwi] ?? 0)
         mangoCountLabel.text = String(describing: fruitStore.storage[.mango] ?? 0)
     }
+}
+
+protocol SupplyViewControllerDelegate: AnyObject {
+    func supplyViewControllerDidExit()
 }

--- a/JuiceMaker/JuiceMaker/Controller/SupplyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/SupplyViewController.swift
@@ -14,11 +14,47 @@ class SupplyViewController: UIViewController {
     @IBOutlet private weak var kiwiCountLabel: UILabel!
     @IBOutlet private weak var mangoCountLabel: UILabel!
     
+    @IBOutlet weak var strawberryStepper: UIStepper!
+    @IBOutlet weak var bananaStepper: UIStepper!
+    @IBOutlet weak var pineappleStepper: UIStepper!
+    @IBOutlet weak var kiwiStepper: UIStepper!
+    @IBOutlet weak var mangoStepper: UIStepper!
+    
     private let fruitStore = FruitStore.shared
     
     override func viewIsAppearing(_ animated: Bool) {
         super.viewIsAppearing(animated)
+        
+        setInitStepperValue()
         reloadFruitsCount()
+    }
+    
+    @IBAction func strawberryStepperTapped(_ sender: UIStepper) {
+        
+    }
+    
+    @IBAction func bananaStepperTapped(_ sender: UIStepper) {
+        
+    }
+    
+    @IBAction func pineappleStepperTapped(_ sender: UIStepper) {
+        
+    }
+    
+    @IBAction func kiwiStepperTapped(_ sender: UIStepper) {
+        
+    }
+    
+    @IBAction func mangoStepperTapped(_ sender: UIStepper) {
+        
+    }
+    
+    private func setInitStepperValue() {
+        strawberryStepper.value = Double(fruitStore.storage[.strawberry] ?? 0)
+        bananaStepper.value = Double(fruitStore.storage[.banana] ?? 0)
+        pineappleStepper.value = Double(fruitStore.storage[.pineapple] ?? 0)
+        kiwiStepper.value = Double(fruitStore.storage[.kiwi] ?? 0)
+        mangoStepper.value = Double(fruitStore.storage[.mango] ?? 0)
     }
     
     private func reloadFruitsCount() {

--- a/JuiceMaker/JuiceMaker/Controller/SupplyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/SupplyViewController.swift
@@ -30,7 +30,7 @@ class SupplyViewController: UIViewController {
     }
     
     @IBAction func closeButtonTapped(_ sender: UIBarButtonItem) {
-        
+        presentingViewController?.dismiss(animated: true)
     }
     
     @IBAction func strawberryStepperTapped(_ sender: UIStepper) {

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -23,13 +23,8 @@ class FruitStore {
     
     private(set) var storage: [Fruit: Int] = [:]
     
-    func updateStock(fruit: Fruit, amount: Int) throws {
-        guard let currentStock = storage[fruit],
-                  (currentStock + amount) >= 0 else {
-            throw StorageError.insufficientStock
-        }
-        
-        storage[fruit]? += amount
+    func updateStock(fruit: Fruit, amount: Int) {
+        storage[fruit] = amount
     }
     
     func consume(fruits: [Fruit: Int]) throws {

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -23,7 +23,7 @@ class FruitStore {
     
     private(set) var storage: [Fruit: Int] = [:]
     
-    func adjustStock(fruit: Fruit, amount: Int) throws {
+    func updateStock(fruit: Fruit, amount: Int) throws {
         guard let currentStock = storage[fruit],
                   (currentStock + amount) >= 0 else {
             throw StorageError.insufficientStock

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -2,7 +2,6 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina5_9" orientation="landscape" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -13,7 +12,7 @@
         <!--맛있는 쥬스를 만들어 드려요!-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController storyboardIdentifier="JuiceViewController" id="BYZ-38-t0r" customClass="JuiceViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="JuiceViewController" id="BYZ-38-t0r" customClass="FruitJuiceOrderViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="812" height="375"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -342,7 +341,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="XFx-xr-4gC" userLabel="Fruit Stack View">
-                                <rect key="frame" x="80" y="122.33333333333331" width="652" height="153.66666666666669"/>
+                                <rect key="frame" x="80" y="122.33333333333333" width="652" height="153.66666666666669"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="WhH-Ur-hiW" userLabel="Strawberry Stack View">
                                         <rect key="frame" x="0.0" y="0.0" width="122.33333333333333" height="153.66666666666666"/>
@@ -584,10 +583,10 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemFillColor">
-            <color red="0.47058823529999999" green="0.47058823529999999" blue="0.50196078430000002" alpha="0.20000000000000001" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.47058823529411764" green="0.47058823529411764" blue="0.50196078431372548" alpha="0.20000000000000001" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemGray5Color">
-            <color red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -126,7 +127,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="strawberryBananaJuiceButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ZKF-MP-Oas"/>
+                                                    <action selector="strawberryBananaJuiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="eLB-w9-esD"/>
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
@@ -141,7 +142,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="mangoKiwiJuiceButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Vu1-2f-Ktq"/>
+                                                    <action selector="mangoKiwiJuiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="vf4-Wm-Pos"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -160,7 +161,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="strawberryJuiceButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="mXy-lX-cSl"/>
+                                                            <action selector="strawberryJuiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="agd-0E-KtV"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
@@ -171,7 +172,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="bananaJuiceButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="vUA-SQ-MWy"/>
+                                                            <action selector="bananaJuiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="bzC-Lb-eKz"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
@@ -182,7 +183,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="pineappleJuiceButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="CTK-Em-N21"/>
+                                                            <action selector="pineappleJuiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="PRX-dS-dUM"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
@@ -193,7 +194,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="kiwiJuiceButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1HK-Og-8pQ"/>
+                                                            <action selector="kiwiJuiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="awu-Av-3Pv"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
@@ -204,7 +205,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="mangoJuiceButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="wJq-lo-ujO"/>
+                                                            <action selector="mangoJuiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ulf-2S-X1k"/>
                                                         </connections>
                                                     </button>
                                                 </subviews>
@@ -237,7 +238,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <action selector="adjustingStockButtonTapped:" destination="BYZ-38-t0r" id="9v5-3N-dQv"/>
+                                <action selector="updatingStockButtonTapped:" destination="BYZ-38-t0r" id="FPV-ug-fF6"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -298,7 +298,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고 수정" id="C3q-Te-cNT" userLabel="재고 수정">
                             <connections>
-                                <action selector="updatingStockButtonTapped:" destination="BYZ-38-t0r" id="FPV-ug-fF6"/>
+                                <action selector="updateStockButtonTapped:" destination="BYZ-38-t0r" id="FPV-ug-fF6"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -342,13 +342,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="XFx-xr-4gC" userLabel="Fruit Stack View">
-                                <rect key="frame" x="80" y="122.33333333333333" width="652" height="153.66666666666669"/>
+                                <rect key="frame" x="80" y="122.33333333333331" width="652" height="153.66666666666669"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="WhH-Ur-hiW" userLabel="Strawberry Stack View">
                                         <rect key="frame" x="0.0" y="0.0" width="122.33333333333333" height="153.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                                <rect key="frame" x="19.333333333333329" y="0.0" width="83.999999999999986" height="83.666666666666671"/>
+                                                <rect key="frame" x="19.333333333333329" y="0.0" width="84" height="83.666666666666671"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="84" id="BYN-cD-ZB2"/>
                                                 </constraints>
@@ -367,7 +367,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                                <rect key="frame" x="14.333333333333329" y="121.66666666666669" width="93.999999999999986" height="32"/>
+                                                <rect key="frame" x="14.333333333333329" y="121.66666666666669" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="strawberryStepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="FKy-je-Jxk"/>
                                                 </connections>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -301,6 +301,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                                 <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="strawberryStepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="FKy-je-Jxk"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
@@ -322,6 +325,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
                                                 <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="bananaStepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="qSF-c6-Nxe"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
@@ -343,6 +349,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
                                                 <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="pineappleStepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="wvY-tF-rdc"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
@@ -364,6 +373,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
                                                 <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="kiwiStepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="GCm-t0-yMI"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
@@ -385,6 +397,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
                                                 <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="mangoStepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="QoQ-j7-7ej"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
@@ -402,10 +417,15 @@
                     <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
                     <connections>
                         <outlet property="bananaCountLabel" destination="gKu-86-RhI" id="CQb-HT-bse"/>
+                        <outlet property="bananaStepper" destination="O5s-2N-3iP" id="gqI-xY-s08"/>
                         <outlet property="kiwiCountLabel" destination="ZDv-1m-HBY" id="Iz5-5E-yuy"/>
+                        <outlet property="kiwiStepper" destination="klA-59-Nu4" id="Dbd-oc-f9h"/>
                         <outlet property="mangoCountLabel" destination="YJI-ER-LJR" id="6lm-cS-qcp"/>
+                        <outlet property="mangoStepper" destination="xbn-6P-grO" id="xsA-fn-vcH"/>
                         <outlet property="pineappleCountLabel" destination="MpT-VW-hCb" id="yTp-Fd-ctY"/>
+                        <outlet property="pineappleStepper" destination="Rcr-xr-eqz" id="bD5-Jn-Ue4"/>
                         <outlet property="strawberryCountLabel" destination="0yV-kn-zaT" id="9aU-VF-N6U"/>
+                        <outlet property="strawberryStepper" destination="ZQk-f4-zrz" id="79I-RI-FxL"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -442,7 +442,7 @@
         <!--Navigation Controller-->
         <scene sceneID="cAf-jL-tPK">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="SupplyViewNavigationController" automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="44"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina5_9" orientation="landscape" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -12,7 +13,7 @@
         <!--맛있는 쥬스를 만들어 드려요!-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController storyboardIdentifier="JuiceViewController" id="BYZ-38-t0r" customClass="FruitJuiceOrderViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="FruitJuiceOrderViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="812" height="375"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -335,7 +336,7 @@
         <!--재고 추가-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
-                <viewController storyboardIdentifier="SupplyViewController" id="Yu1-lM-nqp" customClass="StockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="Yu1-lM-nqp" customClass="StockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
                         <rect key="frame" x="0.0" y="0.0" width="812" height="375"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -583,10 +584,10 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemFillColor">
-            <color red="0.47058823529411764" green="0.47058823529411764" blue="0.50196078431372548" alpha="0.20000000000000001" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.47058823529999999" green="0.47058823529999999" blue="0.50196078430000002" alpha="0.20000000000000001" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemGray5Color">
-            <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
-    <device id="retina6_0" orientation="landscape" appearance="light"/>
+    <device id="retina5_9" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
@@ -15,112 +15,164 @@
             <objects>
                 <viewController storyboardIdentifier="JuiceViewController" id="BYZ-38-t0r" customClass="JuiceViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
+                        <rect key="frame" x="0.0" y="0.0" width="812" height="375"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="63" y="63.999999999999986" width="718" height="136.66666666666663"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF" userLabel="Fruit Stack View">
+                                <rect key="frame" x="66" y="64.000000000000014" width="680" height="131.33333333333337"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="136.66666666666666"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4" userLabel="Strawberry Stack View">
+                                        <rect key="frame" x="0.0" y="0.0" width="123.33333333333333" height="131.33333333333334"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="123.33333333333333" height="97.333333333333329"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="84" id="lcj-aW-NCl"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="105.33333333333334" width="123.33333333333333" height="26"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="26" id="VuB-Jv-avZ"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="mVl-JQ-6g7" firstAttribute="centerX" secondItem="tcB-i6-XX4" secondAttribute="centerX" id="0gE-2X-n0e"/>
+                                            <constraint firstAttribute="trailing" secondItem="Qas-vP-td6" secondAttribute="trailing" id="959-FX-ncL"/>
+                                            <constraint firstItem="Qas-vP-td6" firstAttribute="centerX" secondItem="tcB-i6-XX4" secondAttribute="centerX" id="DIc-z6-Y9G"/>
+                                            <constraint firstItem="Qas-vP-td6" firstAttribute="leading" secondItem="tcB-i6-XX4" secondAttribute="leading" id="U7E-3k-W50"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="136.66666666666666"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo" userLabel="Banana Stack View">
+                                        <rect key="frame" x="139.33333333333334" y="0.0" width="123.00000000000003" height="131.33333333333334"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="123" height="97.333333333333329"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="84" id="zBI-eS-VDA"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="105.33333333333334" width="123" height="26"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="26" id="hLe-8j-72u"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="gvk-pA-Lw5" firstAttribute="centerX" secondItem="G4B-kp-2Jo" secondAttribute="centerX" id="0Sy-RE-Vza"/>
+                                            <constraint firstItem="bl7-p0-c43" firstAttribute="centerX" secondItem="G4B-kp-2Jo" secondAttribute="centerX" id="Ztt-U9-U5G"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="136.66666666666666"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn" userLabel="Pineapple Stack View">
+                                        <rect key="frame" x="278.33333333333331" y="0.0" width="123.33333333333331" height="131.33333333333334"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="123.33333333333333" height="97.333333333333329"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="84" id="uaa-5x-vs2"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="105.33333333333334" width="123.33333333333333" height="26"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="26" id="EfM-tq-a2V"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="Qkv-u6-h8e" firstAttribute="centerX" secondItem="Vji-QZ-gSn" secondAttribute="centerX" id="4id-sa-zO1"/>
+                                            <constraint firstItem="ccQ-Dk-PuY" firstAttribute="centerX" secondItem="Vji-QZ-gSn" secondAttribute="centerX" id="VcV-hj-fdq"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="136.66666666666666"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz" userLabel="Kiwi Stack View">
+                                        <rect key="frame" x="417.66666666666669" y="0.0" width="123.00000000000006" height="131.33333333333334"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="123" height="97.333333333333329"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="84" id="Eqe-a0-eS8"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="105.33333333333334" width="123" height="26"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="26" id="xWL-3K-d4y"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="kI4-bd-cgh" firstAttribute="centerX" secondItem="fKd-3d-9vz" secondAttribute="centerX" id="XEb-Ye-gjN"/>
+                                            <constraint firstItem="FZq-de-TJG" firstAttribute="centerX" secondItem="fKd-3d-9vz" secondAttribute="centerX" id="p19-nd-Wpq"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="136.66666666666666"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m" userLabel="Mango Stack View">
+                                        <rect key="frame" x="556.66666666666663" y="0.0" width="123.33333333333337" height="131.33333333333334"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="123.33333333333333" height="97.333333333333329"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="84" id="CHw-bS-MSX"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="105.33333333333334" width="123.33333333333333" height="26"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="26" id="Sen-jG-vuV"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="2DA-4v-r9P" firstAttribute="centerX" secondItem="dgU-OE-25m" secondAttribute="centerX" id="cuH-6e-l1c"/>
+                                            <constraint firstItem="3Ce-SU-JeH" firstAttribute="centerX" secondItem="dgU-OE-25m" secondAttribute="centerX" id="f69-qM-LFs"/>
+                                        </constraints>
                                     </stackView>
                                 </subviews>
                             </stackView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="63" y="220.66666666666663" width="718" height="128.33333333333337"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D" userLabel="Juice Order Button Stack View">
+                                <rect key="frame" x="66" y="215.33333333333334" width="680" height="118.66666666666666"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="718" height="60"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq" userLabel="First Row Stack View">
+                                        <rect key="frame" x="0.0" y="0.0" width="680" height="55.333333333333336"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="277.66666666666669" height="60"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="262.33333333333331" height="55.333333333333336"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="딸바쥬스 주문">
@@ -131,11 +183,11 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
-                                                <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="60"/>
+                                                <rect key="frame" x="278.33333333333331" y="0.0" width="123.33333333333331" height="55.333333333333336"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="440.33333333333326" y="0.0" width="277.66666666666674" height="60"/>
+                                                <rect key="frame" x="417.66666666666674" y="0.0" width="262.33333333333326" height="55.333333333333336"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
@@ -146,77 +198,85 @@
                                                 </connections>
                                             </button>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="hrc-2F-fzl" firstAttribute="centerY" secondItem="zzl-05-bVq" secondAttribute="centerY" id="Xzj-d1-cho"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="68.000000000000028" width="718" height="60.333333333333343"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM" userLabel="Second Row Stack View">
+                                        <rect key="frame" x="0.0" y="63.333333333333343" width="680" height="55.333333333333343"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="718" height="60.333333333333336"/>
-                                                <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="60.333333333333336"/>
-                                                        <color key="backgroundColor" name="AccentColor"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <state key="normal" title="딸기쥬스 주문">
-                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        </state>
-                                                        <connections>
-                                                            <action selector="strawberryJuiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="agd-0E-KtV"/>
-                                                        </connections>
-                                                    </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="60.333333333333336"/>
-                                                        <color key="backgroundColor" name="AccentColor"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <state key="normal" title="바나나쥬스 주문">
-                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        </state>
-                                                        <connections>
-                                                            <action selector="bananaJuiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="bzC-Lb-eKz"/>
-                                                        </connections>
-                                                    </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
-                                                        <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="60.333333333333336"/>
-                                                        <color key="backgroundColor" name="AccentColor"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <state key="normal" title="파인애플쥬스 주문">
-                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        </state>
-                                                        <connections>
-                                                            <action selector="pineappleJuiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="PRX-dS-dUM"/>
-                                                        </connections>
-                                                    </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="60.333333333333336"/>
-                                                        <color key="backgroundColor" name="AccentColor"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <state key="normal" title="키위쥬스 주문">
-                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        </state>
-                                                        <connections>
-                                                            <action selector="kiwiJuiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="awu-Av-3Pv"/>
-                                                        </connections>
-                                                    </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                        <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="60.333333333333336"/>
-                                                        <color key="backgroundColor" name="AccentColor"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <state key="normal" title="망고쥬스 주문">
-                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        </state>
-                                                        <connections>
-                                                            <action selector="mangoJuiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ulf-2S-X1k"/>
-                                                        </connections>
-                                                    </button>
-                                                </subviews>
-                                            </stackView>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
+                                                <rect key="frame" x="0.0" y="0.0" width="123.33333333333333" height="55.333333333333336"/>
+                                                <color key="backgroundColor" name="AccentColor"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <state key="normal" title="딸기쥬스 주문">
+                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="strawberryJuiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="agd-0E-KtV"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
+                                                <rect key="frame" x="139.33333333333334" y="0.0" width="123.00000000000003" height="55.333333333333336"/>
+                                                <color key="backgroundColor" name="AccentColor"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <state key="normal" title="바나나쥬스 주문">
+                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="bananaJuiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="bzC-Lb-eKz"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
+                                                <rect key="frame" x="278.33333333333331" y="0.0" width="123.33333333333331" height="55.333333333333336"/>
+                                                <color key="backgroundColor" name="AccentColor"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <state key="normal" title="파인애플쥬스 주문">
+                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="pineappleJuiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="PRX-dS-dUM"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
+                                                <rect key="frame" x="417.66666666666669" y="0.0" width="123.00000000000006" height="55.333333333333336"/>
+                                                <color key="backgroundColor" name="AccentColor"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <state key="normal" title="키위쥬스 주문">
+                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="kiwiJuiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="awu-Av-3Pv"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
+                                                <rect key="frame" x="556.66666666666663" y="0.0" width="123.33333333333337" height="55.333333333333336"/>
+                                                <color key="backgroundColor" name="AccentColor"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <state key="normal" title="망고쥬스 주문">
+                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="mangoJuiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ulf-2S-X1k"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="q6G-4X-bVm" firstAttribute="centerY" secondItem="Pnn-0B-qbM" secondAttribute="centerY" id="YHC-6O-mrJ"/>
+                                        </constraints>
                                     </stackView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="ngP-kF-Yii" firstAttribute="leading" secondItem="wcW-7H-RXw" secondAttribute="leading" id="Fnc-pf-ciE"/>
-                                    <constraint firstItem="y2A-PH-DJY" firstAttribute="trailing" secondItem="hrc-2F-fzl" secondAttribute="trailing" id="Fu0-qW-GJ8"/>
-                                    <constraint firstItem="ngP-kF-Yii" firstAttribute="trailing" secondItem="q6G-4X-bVm" secondAttribute="trailing" id="IRM-sD-zPp"/>
+                                    <constraint firstItem="hrc-2F-fzl" firstAttribute="trailing" secondItem="y2A-PH-DJY" secondAttribute="trailing" id="0qL-4u-CeQ"/>
+                                    <constraint firstItem="zzl-05-bVq" firstAttribute="leading" secondItem="vaj-6k-c2D" secondAttribute="leading" id="1D3-wU-Chm"/>
+                                    <constraint firstItem="ngP-kF-Yii" firstAttribute="trailing" secondItem="q6G-4X-bVm" secondAttribute="trailing" id="BWi-6k-hNA"/>
+                                    <constraint firstItem="hrc-2F-fzl" firstAttribute="leading" secondItem="avd-o5-3JM" secondAttribute="leading" id="Olf-ng-LAZ"/>
+                                    <constraint firstAttribute="trailing" secondItem="Pnn-0B-qbM" secondAttribute="trailing" id="QkS-fA-7ZN"/>
+                                    <constraint firstItem="9E2-H9-FXr" firstAttribute="leading" secondItem="BFb-ka-wGA" secondAttribute="leading" id="aap-yH-GkR"/>
+                                    <constraint firstItem="9E2-H9-FXr" firstAttribute="trailing" secondItem="BFb-ka-wGA" secondAttribute="trailing" id="dJU-d8-fRA"/>
+                                    <constraint firstItem="Pnn-0B-qbM" firstAttribute="leading" secondItem="vaj-6k-c2D" secondAttribute="leading" id="g7p-l6-dv2"/>
+                                    <constraint firstAttribute="trailing" secondItem="zzl-05-bVq" secondAttribute="trailing" id="i2N-34-HUH"/>
+                                    <constraint firstItem="ngP-kF-Yii" firstAttribute="leading" secondItem="wcW-7H-RXw" secondAttribute="leading" id="o5c-Ou-LYC"/>
                                 </constraints>
                             </stackView>
                         </subviews>
@@ -226,8 +286,8 @@
                             <constraint firstItem="vaj-6k-c2D" firstAttribute="leading" secondItem="zaq-m5-IIF" secondAttribute="leading" id="4Ki-Xs-fjI"/>
                             <constraint firstItem="zaq-m5-IIF" firstAttribute="height" secondItem="8bC-Xf-vdC" secondAttribute="height" multiplier="35%" id="5ly-0F-l0U"/>
                             <constraint firstItem="Pnn-0B-qbM" firstAttribute="trailing" secondItem="dgU-OE-25m" secondAttribute="trailing" id="6U9-bI-g7g"/>
-                            <constraint firstItem="hrc-2F-fzl" firstAttribute="trailing" secondItem="G4B-kp-2Jo" secondAttribute="trailing" id="JP9-5g-NDg"/>
                             <constraint firstItem="zaq-m5-IIF" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="Vlw-OR-dfY"/>
+                            <constraint firstItem="zaq-m5-IIF" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Yyv-6e-Eqw"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="vaj-6k-c2D" secondAttribute="bottom" constant="20" id="ea1-Np-zdi"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="zaq-m5-IIF" secondAttribute="trailing" constant="16" id="f8U-FF-gSK"/>
                             <constraint firstItem="vaj-6k-c2D" firstAttribute="trailing" secondItem="zaq-m5-IIF" secondAttribute="trailing" id="fHg-kF-51g"/>
@@ -236,7 +296,7 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
-                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
+                        <barButtonItem key="rightBarButtonItem" title="재고 수정" id="C3q-Te-cNT" userLabel="재고 수정">
                             <connections>
                                 <action selector="updatingStockButtonTapped:" destination="BYZ-38-t0r" id="FPV-ug-fF6"/>
                             </connections>
@@ -260,7 +320,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DCG-dP-Fms" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="wpg-nM-F9y">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="812" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" systemColor="systemFillColor"/>
                     </navigationBar>
@@ -278,131 +338,188 @@
             <objects>
                 <viewController storyboardIdentifier="SupplyViewController" id="Yu1-lM-nqp" customClass="StockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
+                        <rect key="frame" x="0.0" y="0.0" width="812" height="375"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="38" translatesAutoresizingMaskIntoConstraints="NO" id="XFx-xr-4gC">
-                                <rect key="frame" x="77" y="74" width="690" height="156"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="XFx-xr-4gC" userLabel="Fruit Stack View">
+                                <rect key="frame" x="80" y="122.33333333333333" width="652" height="153.66666666666669"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="WhH-Ur-hiW">
-                                        <rect key="frame" x="0.0" y="0.0" width="94" height="156"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="WhH-Ur-hiW" userLabel="Strawberry Stack View">
+                                        <rect key="frame" x="0.0" y="0.0" width="122.33333333333333" height="153.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                                <rect key="frame" x="9.6666666666666714" y="0.0" width="75" height="85.666666666666671"/>
+                                                <rect key="frame" x="19.333333333333329" y="0.0" width="83.999999999999986" height="83.666666666666671"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="84" id="BYN-cD-ZB2"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                                <rect key="frame" x="40.333333333333329" y="91.666666666666657" width="13.333333333333336" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="89.666666666666671" width="122.33333333333333" height="26"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="26" id="y8b-ak-g34"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                                <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <rect key="frame" x="14.333333333333329" y="121.66666666666669" width="93.999999999999986" height="32"/>
                                                 <connections>
                                                     <action selector="strawberryStepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="FKy-je-Jxk"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="0yV-kn-zaT" firstAttribute="leading" secondItem="WhH-Ur-hiW" secondAttribute="leading" id="8fH-D5-DVz"/>
+                                            <constraint firstItem="dCK-AJ-zGU" firstAttribute="centerX" secondItem="WhH-Ur-hiW" secondAttribute="centerX" id="D2O-da-h9p"/>
+                                            <constraint firstItem="ZQk-f4-zrz" firstAttribute="centerX" secondItem="WhH-Ur-hiW" secondAttribute="centerX" id="lK6-RG-9KW"/>
+                                            <constraint firstAttribute="trailing" secondItem="0yV-kn-zaT" secondAttribute="trailing" id="os6-dD-Ial"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="2vQ-0F-6ZU">
-                                        <rect key="frame" x="149" y="0.0" width="94" height="156"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="2vQ-0F-6ZU" userLabel="Banana Stack View">
+                                        <rect key="frame" x="132.33333333333334" y="0.0" width="122.33333333333334" height="153.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                                <rect key="frame" x="9.6666666666666572" y="0.0" width="75" height="91.666666666666671"/>
+                                                <rect key="frame" x="19.333333333333314" y="0.0" width="84" height="83.666666666666671"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="84" id="eSj-Cb-nrC"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                                <rect key="frame" x="40.333333333333314" y="94.666666666666657" width="13.333333333333336" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="89.666666666666671" width="122.33333333333333" height="26"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="26" id="sKq-C2-k8w"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                                <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <rect key="frame" x="14.333333333333314" y="121.66666666666669" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="bananaStepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="qSF-c6-Nxe"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="trailing" secondItem="gKu-86-RhI" secondAttribute="trailing" id="4aO-NW-JoV"/>
+                                            <constraint firstItem="gKu-86-RhI" firstAttribute="leading" secondItem="2vQ-0F-6ZU" secondAttribute="leading" id="Lxm-dv-Qhe"/>
+                                            <constraint firstItem="y33-ND-gz2" firstAttribute="centerX" secondItem="2vQ-0F-6ZU" secondAttribute="centerX" id="NSr-tO-VJm"/>
+                                            <constraint firstItem="O5s-2N-3iP" firstAttribute="centerX" secondItem="2vQ-0F-6ZU" secondAttribute="centerX" id="dfz-dG-dtb"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="63T-By-0rH">
-                                        <rect key="frame" x="298" y="0.0" width="94" height="156"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="63T-By-0rH" userLabel="Pineapple Stack View">
+                                        <rect key="frame" x="264.66666666666669" y="0.0" width="122.66666666666669" height="153.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                                <rect key="frame" x="9.6666666666666856" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="19.333333333333314" y="0.0" width="84" height="83.666666666666671"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="84" id="ENN-k5-7qi"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                                <rect key="frame" x="40.333333333333314" y="90.666666666666657" width="13.333333333333336" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="89.666666666666671" width="122.66666666666667" height="26"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="26" id="hku-md-jdy"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                                <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <rect key="frame" x="14.333333333333314" y="121.66666666666669" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="pineappleStepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="wvY-tF-rdc"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="Rcr-xr-eqz" firstAttribute="centerX" secondItem="63T-By-0rH" secondAttribute="centerX" id="l6Z-Sp-Zjx"/>
+                                            <constraint firstAttribute="trailing" secondItem="MpT-VW-hCb" secondAttribute="trailing" id="m7C-xX-6MV"/>
+                                            <constraint firstItem="MpT-VW-hCb" firstAttribute="leading" secondItem="63T-By-0rH" secondAttribute="leading" id="sCS-lU-KcU"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="pHs-0z-pAE">
-                                        <rect key="frame" x="447" y="0.0" width="94" height="156"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="pHs-0z-pAE" userLabel="Kiwi Stack View">
+                                        <rect key="frame" x="397.33333333333331" y="0.0" width="122.33333333333331" height="153.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                                <rect key="frame" x="9.6666666666666288" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="19" y="0.0" width="84" height="83.666666666666671"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="84" id="xQQ-Ib-p82"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                                <rect key="frame" x="40.333333333333371" y="90.666666666666657" width="13.333333333333336" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="89.666666666666671" width="122.33333333333333" height="26"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="26" id="Pnq-fv-Bhr"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                                <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <rect key="frame" x="14" y="121.66666666666669" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="kiwiStepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="GCm-t0-yMI"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="klA-59-Nu4" firstAttribute="centerX" secondItem="pHs-0z-pAE" secondAttribute="centerX" id="7Sy-RV-jVH"/>
+                                            <constraint firstAttribute="trailing" secondItem="ZDv-1m-HBY" secondAttribute="trailing" id="cuW-lK-HGy"/>
+                                            <constraint firstItem="ZDv-1m-HBY" firstAttribute="leading" secondItem="pHs-0z-pAE" secondAttribute="leading" id="l7w-Vx-KnJ"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="hzx-ux-cRz">
-                                        <rect key="frame" x="596" y="0.0" width="94" height="156"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="hzx-ux-cRz" userLabel="Mango Stack View">
+                                        <rect key="frame" x="529.66666666666663" y="0.0" width="122.33333333333337" height="153.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                                <rect key="frame" x="9.6666666666666288" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="19" y="0.0" width="84" height="83.666666666666671"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="84" id="aog-t9-8zD"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                                <rect key="frame" x="40.333333333333371" y="90.666666666666657" width="13.333333333333336" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="89.666666666666671" width="122.33333333333333" height="26"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="26" id="AZZ-dx-oXT"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                                <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <rect key="frame" x="14" y="121.66666666666669" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="mangoStepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="QoQ-j7-7ej"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="trailing" secondItem="YJI-ER-LJR" secondAttribute="trailing" id="Fuw-qo-P8k"/>
+                                            <constraint firstItem="YJI-ER-LJR" firstAttribute="leading" secondItem="hzx-ux-cRz" secondAttribute="leading" id="Lbu-Rm-T8l"/>
+                                            <constraint firstItem="xbn-6P-grO" firstAttribute="centerX" secondItem="hzx-ux-cRz" secondAttribute="centerX" id="zIL-cf-Dg1"/>
+                                        </constraints>
                                     </stackView>
                                 </subviews>
                             </stackView>
@@ -410,8 +527,8 @@
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="XFx-xr-4gC" firstAttribute="centerY" secondItem="gcO-Xb-kNs" secondAttribute="centerY" id="BuF-x8-YWW"/>
                             <constraint firstItem="gcO-Xb-kNs" firstAttribute="trailing" secondItem="XFx-xr-4gC" secondAttribute="trailing" constant="30" id="JTp-WG-daV"/>
-                            <constraint firstItem="XFx-xr-4gC" firstAttribute="top" secondItem="gcO-Xb-kNs" secondAttribute="top" constant="30" id="Tdr-19-cb2"/>
                             <constraint firstItem="XFx-xr-4gC" firstAttribute="leading" secondItem="gcO-Xb-kNs" secondAttribute="leading" constant="30" id="bBq-hT-y7m"/>
                         </constraints>
                     </view>
@@ -445,7 +562,7 @@
                 <navigationController storyboardIdentifier="StockViewNavigationController" automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="812" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" systemColor="systemFillColor"/>
                     </navigationBar>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -276,7 +276,7 @@
         <!--재고 추가-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
-                <viewController storyboardIdentifier="SupplyViewController" id="Yu1-lM-nqp" customClass="SupplyViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SupplyViewController" id="Yu1-lM-nqp" customClass="StockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -442,7 +442,7 @@
         <!--Navigation Controller-->
         <scene sceneID="cAf-jL-tPK">
             <objects>
-                <navigationController storyboardIdentifier="SupplyViewNavigationController" automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="StockViewNavigationController" automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="44"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -262,6 +262,7 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="wpg-nM-F9y">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" systemColor="systemFillColor"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
@@ -272,7 +273,7 @@
             </objects>
             <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
         </scene>
-        <!--Supply View Controller-->
+        <!--재고 추가-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
                 <viewController storyboardIdentifier="SupplyViewController" id="Yu1-lM-nqp" customClass="SupplyViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
@@ -414,7 +415,13 @@
                             <constraint firstItem="XFx-xr-4gC" firstAttribute="leading" secondItem="gcO-Xb-kNs" secondAttribute="leading" constant="30" id="bBq-hT-y7m"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
+                    <navigationItem key="navigationItem" title="재고 추가" id="g4W-fY-l7r">
+                        <barButtonItem key="rightBarButtonItem" title="닫기" id="sn9-R4-yYr">
+                            <connections>
+                                <action selector="closeButtonTapped:" destination="Yu1-lM-nqp" id="Wg0-da-LgC"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <outlet property="bananaCountLabel" destination="gKu-86-RhI" id="CQb-HT-bse"/>
                         <outlet property="bananaStepper" destination="O5s-2N-3iP" id="gqI-xY-s08"/>
@@ -440,6 +447,7 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" systemColor="systemFillColor"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
@@ -457,6 +465,9 @@
         </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemFillColor">
+            <color red="0.47058823529999999" green="0.47058823529999999" blue="0.50196078430000002" alpha="0.20000000000000001" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemGray5Color">
             <color red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -400,11 +400,11 @@
                     </view>
                     <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
                     <connections>
-                        <outlet property="bananaCount" destination="gKu-86-RhI" id="CQb-HT-bse"/>
-                        <outlet property="kiwiCount" destination="ZDv-1m-HBY" id="Iz5-5E-yuy"/>
-                        <outlet property="mangoCount" destination="YJI-ER-LJR" id="6lm-cS-qcp"/>
-                        <outlet property="pineappleCount" destination="MpT-VW-hCb" id="yTp-Fd-ctY"/>
-                        <outlet property="strawberryCount" destination="0yV-kn-zaT" id="9aU-VF-N6U"/>
+                        <outlet property="bananaCountLabel" destination="gKu-86-RhI" id="CQb-HT-bse"/>
+                        <outlet property="kiwiCountLabel" destination="ZDv-1m-HBY" id="Iz5-5E-yuy"/>
+                        <outlet property="mangoCountLabel" destination="YJI-ER-LJR" id="6lm-cS-qcp"/>
+                        <outlet property="pineappleCountLabel" destination="MpT-VW-hCb" id="yTp-Fd-ctY"/>
+                        <outlet property="strawberryCountLabel" destination="0yV-kn-zaT" id="9aU-VF-N6U"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,102 @@
-# ios-juice-maker
-쥬스메이커 프로젝트 저장소입니다. 
+# Project 02. 쥬스자판기
+
+## 목차
+> [1. Overview](#Overview)
+>
+> [2. Key Topics](#Key-Topics)
+>
+> [3. 프로그램 화면 예시](#프로그램-화면-예시)
+>
+> [4. 프로그램 설명](#프로그램-설명)
+>
+> [5. 이번 프로젝트를 통해 배운 것](#이번-프로젝트를-통해-배운-것)
+>
+> [6. 회고](#회고)
+
+## Overview
+
+MVC 패턴을 적용한 실습용 프로젝트입니다.
+storyboard 를 활용하여 화면을 구성하고, 이를 실제 코드와 연동하는 과정을 학습했습니다.
+
+## Key Topics
+- 타입의 캡슐화/은닉화
+- 내비게이션 바 및 버튼 아이템의 활용
+- 얼럿 컨트롤러 활용
+- Modality의 활용
+- 화면 사이의 데이터 공유
+- 오토레이아웃 적용해보기
+- Protocol / Extension 활용
+- MVC 패턴의 이해
+
+## 프로그램 화면 예시
+
+### 쥬스 주문 화면
+![스크린샷 2023-12-22 오후 1 42 55](https://github.com/eensungkim/ios-juice-maker/assets/73898006/7fe50e0a-98d3-4879-9a91-e87398793809)
+
+### 쥬스 주문 성공 시
+![스크린샷 2023-12-22 오후 1 43 00](https://github.com/eensungkim/ios-juice-maker/assets/73898006/19b86d4d-4427-41ef-9ca6-6db8304f8e21)
+
+### 재고 부족 시
+![스크린샷 2023-12-22 오후 1 43 06](https://github.com/eensungkim/ios-juice-maker/assets/73898006/24a21a12-110f-41ca-9cec-bf4deabf18ad)
+
+### 재고 수정 화면
+![스크린샷 2023-12-22 오후 1 43 11](https://github.com/eensungkim/ios-juice-maker/assets/73898006/f344e98e-e15a-41a9-afef-133348ab7783)
+
+## 프로그램 설명
+### Model
+**JuiceMaker.swift**
+- **enum Menu** : 과일쥬스의 종류, recipe property는 쥬스 제작에 필요한 과일 수량 명시
+- **makeJuice()** : fruitStore 싱글턴 객체에 과일 재고 소비를 요청
+
+**FruitStore.swift**
+- **enum Fruit** : 과일의 종류
+- **enum StorageError** : 재고부족에러
+- **storage** : 과일 재고 딕셔너리
+- **updateStock()** : 재고 변경
+- **consume()** : 재고 소비 메서드, 재고가 부족한 경우 에러 출력
+- **setUpInitialFruitsStock()** : 초기화 시 storage 에 과일 재고 수량을 10만큼 할당
+
+### View
+**Main.storyboard**
+- **쥬스 주문 화면** : 과일의 현재 재고 및 주문 버튼 출력, 재고수정 버튼을 클릭해 재고수정 화면으로 이동
+- **재고 추가 화면** : 과일의 재고 수량을 변경, 닫기 버튼으로 쥬스 주문 화면으로 이동
+
+### Controller
+**FruitJuiceOrderViewController.swift**
+- **presentStockViewController()** : 재고 추가 화면으로 이동하는 로직, 위임패턴을 활용해 reloadFruitsCount() 기능 위임
+- **orderJuice()** : juiceMaker 객체에 makeJuice() 요청, 성공한 경우 쥬스 수령 alert, 재고가 모자란 경우 재고추가 화면 이동 여부 alert
+- **reloadFruitsCount()** : 화면의 label 값을 현재 재고 수량으로 연동
+- **alertJuiceServed()** : 쥬스 수령 alert
+- **alertInsufficientStock()** : 재고 수정 alert, '예' 선택 시 재고 수정 화면으로 이동
+- **stockViewWillDisappear()** : delegate 패턴 활용하여 reloadFruitsCount() 위임
+- 그 외 과일 재고 Label, 과일쥬스 주문 버튼에 연동된 @IBOutlet, @IBAction
+
+**StockViewController.swift**
+- **updateStock()** : 재고 변경 요청 및 화면 반영
+- **reloadFruitsCount()** : 재고 수량 화면 반영
+- **setInitialStepperValues()** : 스테퍼의 초기값을 재고 수량과 연동
+- 그 외 과일 재고 Label, Stepper 와 연동된 @IBOutlet, @IBAction
+
+### Sequence Diagram
+**쥬스 주문 화면**
+![OrderJuice](https://github.com/eensungkim/ios-juice-maker/assets/73898006/e1227c16-69e8-485d-9188-87687b6318ed)
+
+**재고 수정 화면**
+![UpdateStock](https://github.com/eensungkim/ios-juice-maker/assets/73898006/94a207b7-9b61-4216-9ccd-0a32520ff358)
+
+## 이번 프로젝트를 통해 배운 것
+**UIViewController의 메서드로 관리되는 view의 생명주기**
+- **viewIsAppearing()** : view가 onscreen 에 나타날 때 콘텐츠의 변화를 view에 반영하려면 이 메서드에 적용. 
+공식문서는 viewWillAppear() 대신 viewIsAppearing() 활용을 권장
+[참고문서 링크](https://developer.apple.com/documentation/uikit/view_controllers/displaying_and_managing_views_with_a_view_controller#3370691)
+
+**Delegate(위임) 패턴**
+- 프로토콜을 활용하여 위임 패턴 구현 가능
+- 프로토콜을 타입으로 활용하여 전달하기 때문에 프로토콜에서 요구하는 내용만 위임할 수 있음
+
+
+
+## 회고
+storyboard의 view와  viewController 와 연동하고, auto layout 을 활용해 반응성있는 화면을 구현해볼 수 있었습니다.
+또한 이 과정에서 내비게이션과 모달을 활용한 화면 전환 방법, view의 생명주기 등을 새롭게 이해하게 되었습니다.
+그리고 프로젝트를 통해 싱글턴, Protocol 과 Delegation 패턴 활용 등을 학습하고 적용해볼 수 있었습니다.


### PR DESCRIPTION
Step 3
멤버 : @eensungkim, @llamang
리뷰어 : @minsson

쥬스 자판기 프로젝트의 마지막 Step입니다! 
정리하여 PR 드립니다. 감사합니다!

# 리뷰 추가 반영사항

- 변수 네이밍 수정 반영
- `.description` 대신 `String(describing:)` 활용

# Step 3 구현내용
## Sequence 다이어그램
[![스크린샷 2023-12-20 오후 4 42 47](https://github.com/tasty-code/ios-juice-maker/assets/73898006/152bd771-3d17-4f48-a697-cf8004696978)](#)

## 재고 수정 화면
- 제목 추가 및 닫기 버튼 구현
- 현재 재고 수량을 Label에 반영
- Stepper를 활용한 재고 수정 기능
- 오토레이아웃 적용

## JuiceViewController.swift
showStockViewModal() : 기존 내비게이션 컨트롤러를 활용한 이동에서 모달을 활용한 이동으로 변경 구현

extension JuiceViewController: StockViewControllerDelegate : 재고 수정 화면의 모달을 빠져나올 때 수정된 재고가 기존의 쥬스 화면에 반영될 수 있도록 위임 패턴을 활용하여 구현


## StockViewController.swift
override func viewWillDisappear(_ animated: Bool) : 모달이 종료될 때 위임받은 메서드 실행

closeButtonTapped() : 닫기 버튼을 클릭하면 모달 종료

setInitialStepperValues() : 현재 재고를 스테퍼의 초기 밸류와 연동

protocol StockViewControllerDelegate: AnyObject : 위임 패턴 활용을 위한 프로토콜 구현
[Delegation](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/protocols/#Delegation) 문서를 참고했습니다. 

## FruitStore.swift
updateStock() : 
1. 네이밍 변경
2. 스테퍼와의 연동을 위해 재고 전체를 전달받은 `amount: Int`로 변경하도록 수정
3. 불필요한 에러 처리 제거

## 그 외
- 재고 수정 메서드인 reloadFruitsCount() 를 viewDidLoad() 가 아닌 viewIsAppearing() 에서 호출하도록 변경

# 질문
- 댄 : 화면 전환 방식을 내비게이션에서 모달로 변경하면서, JuiceViewController 의 생명주기 메서드들이 동작하지 않는 상황이 있었습니다. 이를 해결하기 위해 위임 패턴을 활용해서 JuiceViewController 의 메서드를 모달의 뷰로 전달해줘야 했었는데요.
모달을 적용해보고 공부한다는 입장에서 적용해보았지만, 내비게이션 방식이 좀 더 어울린다고도 판단이 들었습니다. 기획의 차이가 아닐까 싶은데요. 내비게이션과 모달 사이에서 선택할 때 민쏜님은 어떤 기준으로 구분하시는지 궁금합니다.
- 라마 :
    
    Stepper를 활용해 기존 `FruitStore`의 `updateStock` 메서드를 사용하려면, `Int(sender.value) - (fruitStore.storage[.pineapple] ?? 0)` 같은 추가적인 연산이 필요했습니다. 
    
    왜냐하면 기존의 재고에 수량을 더하거나(`amount > 0`) 빼는(`amount < 0`) 방식이기 때문입니다. 
    
    ```swift
        func updateStock(fruit: Fruit, amount: Int) throws {
            guard let currentStock = storage[fruit],
                      (currentStock + amount) >= 0 else {
                throw StorageError.insufficientStock
            }
            
            storage[fruit]? += amount
        }
    ```
    
    ```swift
        @IBAction private func pineappleStepperTapped(_ sender: UIStepper) {
            updateStock(fruit: .pineapple, amount: Int(sender.value) - (fruitStore.storage[.pineapple] ?? 0))
        }
    
        private func updateStock(fruit: FruitStore.Fruit, amount: Int) {
            fruitStore.updateStock(fruit: fruit, amount: amount)
            reloadFruitsCount()
        }
    ```
    
    이번 프로젝트에서 `FruitStore`의 `updateStock` 메서드는 Stepper를 통해서만 사용됩니다. 
    
    따라서 `Int(sender.value) - (fruitStore.storage[.pineapple] ?? 0)` 같은 추가적인 연산을 제거하고자, 다음과 같이 기존 재고와 상관없이 수량을 업데이트하는 메서드로 구현을 변경했습니다. 
    
    ```swift
        func updateStock(fruit: Fruit, amount: Int) {
            storage[fruit] = amount
        }
    ```
    
    ```swift
        @IBAction private func pineappleStepperTapped(_ sender: UIStepper) {
            updateStock(fruit: .pineapple, amount: Int(sender.value))
        }    
    
        private func updateStock(fruit: FruitStore.Fruit, amount: Int) {
            fruitStore.updateStock(fruit: fruit, amount: amount)
            reloadFruitsCount()
        }
    ```
    
    해당 변경으로 인해 Stepper를 통한 `FruitStore`의 재고를 업데이트하는 구현은 간단해졌지만, 기존 재고와 상관없이 수량을 setter 방식으로 업데이트하는 것이 어색하게 느껴집니다.
