### PR TITLE
쥬스 자판기 [STEP 3] Jane, Harry

### DIFF
--- a/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
@@ -84,7 +84,7 @@ extension OrderViewController {
     
     private func configureUI() {
         for (fruit, label) in labelsByFruit {
-            let fruitQuantity = fruitStore.checkFruitQuantity(of: fruit)
+            let fruitQuantity = fruitStore.quantity(of: fruit)
             label.text = String(fruitQuantity)
         }
     }

--- a/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
@@ -28,7 +28,7 @@ final class OrderViewController: UIViewController {
     
     // MARK: Initializer
     required init?(coder aDecoder: NSCoder) {
-        self.fruitStore = FruitStore.init(fruitContainer: [
+        self.fruitStore = FruitStore(fruitContainer: [
             .strawberry: 10,
             .banana: 10,
             .kiwi: 10,
@@ -84,7 +84,6 @@ extension OrderViewController {
     
     private func configureUI() {
         for (fruit, label) in labelsByFruit {
-            label.text = String(fruitStore.fetchFruitQuantity(of: fruit))
         }
     }
     
@@ -92,12 +91,10 @@ extension OrderViewController {
         guard let nextViewController = self.storyboard?.instantiateViewController(withIdentifier: InventoryViewController.className)
                 as? InventoryViewController else { return }
         
-        nextViewController.setUpFruitContainerData(fruitStore.fetchFruitContainer())
         nextViewController.modalPresentationStyle = .fullScreen
         self.present(nextViewController, animated: true)
     }
     
     func setUpFruitContainer(data: [Fruit: Int]) {
-        fruitStore.updateFruitContainer(data)
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
@@ -45,7 +45,7 @@ final class OrderViewController: UIViewController {
     }
 
     // MARK: @IBAction
-    @IBAction private func tapEditInventoryButton(_ sender: UIBarButtonItem) {
+    @IBAction private func tapEditInventoryButton(_ sender: UIButton) {
         pushInventoryViewController()
     }
     
@@ -86,6 +86,8 @@ extension OrderViewController {
         guard let nextViewController = self.storyboard?.instantiateViewController(withIdentifier: InventoryViewController.className)
                 as? UIViewController else { return }
         
-        self.navigationController?.pushViewController(nextViewController, animated: true)
+        nextViewController.modalPresentationStyle = .fullScreen
+        
+        self.present(nextViewController, animated: true)
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
@@ -90,15 +90,15 @@ extension OrderViewController {
     }
     
     private func presentInventoryViewController() {
-        guard let nextViewController = self.storyboard?.instantiateViewController(withIdentifier: InventoryViewController.className)
-                as? InventoryViewController else { return }
-        
         let fruitInventory = fruitStore.checkFruitContainer()
-        nextViewController.setUpFruitContainer(data: fruitInventory)
+        guard let nextViewController = self.storyboard?.instantiateViewController(identifier: InventoryViewController.className, creator: { coder in
+            return InventoryViewController(coder: coder, fruitStore: FruitStore(fruitContainer: fruitInventory))
+        }) else { return }
+        
         nextViewController.modalPresentationStyle = .fullScreen
         self.present(nextViewController, animated: true)
     }
-    
+
     func setUpFruitContainer(data: [Fruit: Int]) {
         fruitStore.updateFruitContainer(with: data)
     }

--- a/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
@@ -90,9 +90,8 @@ extension OrderViewController {
     }
     
     private func presentInventoryViewController() {
-        let fruitInventory = fruitStore.checkFruitContainer()
         guard let nextViewController = self.storyboard?.instantiateViewController(identifier: InventoryViewController.className, creator: { coder in
-            return InventoryViewController(coder: coder, fruitStore: FruitStore(fruitContainer: fruitInventory))
+            return InventoryViewController(coder: coder, fruitStore: self.fruitStore)
         }) else { return }
         
         nextViewController.modalPresentationStyle = .fullScreen

--- a/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
@@ -16,7 +16,7 @@ final class OrderViewController: UIViewController {
     @IBOutlet private weak var mangoQuantityLabel: UILabel!
     
     // MARK: Properties
-    private var fruitStore: FruitStore
+    private let fruitStore: FruitStore
     private let juiceMaker: JuiceMaker
     private lazy var labelsByFruit: [Fruit: UILabel] = [
         .strawberry: strawberryQuantityLabel,
@@ -28,8 +28,14 @@ final class OrderViewController: UIViewController {
     
     // MARK: Initializer
     required init?(coder aDecoder: NSCoder) {
-        self.fruitStore = FruitStore.shared
-        self.juiceMaker = JuiceMaker()
+        self.fruitStore = FruitStore.init(fruitContainer: [
+            .strawberry: 10,
+            .banana: 10,
+            .kiwi: 10,
+            .pineapple: 10,
+            .mango: 10,
+        ])
+        self.juiceMaker = JuiceMaker(fruitStore: self.fruitStore)
         super.init(coder: aDecoder)
     }
     
@@ -46,7 +52,7 @@ final class OrderViewController: UIViewController {
 
     // MARK: @IBAction
     @IBAction private func tapEditInventoryButton(_ sender: UIButton) {
-        pushInventoryViewController()
+        presentInventoryViewController()
     }
     
     @IBAction private func tapMakeJuiceButton(_ sender: UIButton) {
@@ -67,7 +73,7 @@ final class OrderViewController: UIViewController {
                                    confirmTitle: "예",
                                    cancelTitle: "아니오",
                                    confirmAction: { [weak self] _ in
-                self?.pushInventoryViewController()
+                self?.presentInventoryViewController()
             })
         }
     }
@@ -78,16 +84,20 @@ extension OrderViewController {
     
     private func configureUI() {
         for (fruit, label) in labelsByFruit {
-            label.text = String(fruitStore.fruitContainer[fruit, default: 0])
+            label.text = String(fruitStore.fetchFruitQuantity(of: fruit))
         }
     }
     
-    private func pushInventoryViewController() {
+    private func presentInventoryViewController() {
         guard let nextViewController = self.storyboard?.instantiateViewController(withIdentifier: InventoryViewController.className)
-                as? UIViewController else { return }
+                as? InventoryViewController else { return }
         
+        nextViewController.setUpFruitContainerData(fruitStore.fetchFruitContainer())
         nextViewController.modalPresentationStyle = .fullScreen
-        
         self.present(nextViewController, animated: true)
+    }
+    
+    func setUpFruitContainer(data: [Fruit: Int]) {
+        fruitStore.updateFruitContainer(data)
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/OrderViewController.swift
@@ -84,6 +84,8 @@ extension OrderViewController {
     
     private func configureUI() {
         for (fruit, label) in labelsByFruit {
+            let fruitQuantity = fruitStore.checkFruitQuantity(of: fruit)
+            label.text = String(fruitQuantity)
         }
     }
     
@@ -91,10 +93,13 @@ extension OrderViewController {
         guard let nextViewController = self.storyboard?.instantiateViewController(withIdentifier: InventoryViewController.className)
                 as? InventoryViewController else { return }
         
+        let fruitInventory = fruitStore.checkFruitContainer()
+        nextViewController.setUpFruitContainer(data: fruitInventory)
         nextViewController.modalPresentationStyle = .fullScreen
         self.present(nextViewController, animated: true)
     }
     
     func setUpFruitContainer(data: [Fruit: Int]) {
+        fruitStore.updateFruitContainer(with: data)
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -21,7 +21,7 @@ final class FruitStore {
         return fruitContainer
     }
     
-    func checkFruitQuantity(of fruit: Fruit) -> Int {
+    func quantity(of fruit: Fruit) -> Int {
         return fruitContainer[fruit, default: 0]
     }
     

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -17,15 +17,15 @@ final class FruitStore {
     }
     
     // MARK: Custom Methods
-    func fetchFruitContainer() -> [Fruit: Int] {
+    func checkFruitContainer() -> [Fruit: Int] {
         return fruitContainer
     }
     
-    func fetchFruitQuantity(of fruit: Fruit) -> Int {
-        return fruitContainer[fruit, default: 0] 
+    func checkFruitQuantity(of fruit: Fruit) -> Int {
+        return fruitContainer[fruit, default: 0]
     }
     
-    func updateFruitContainer(_ data: [Fruit: Int]) {
+    func updateFruitContainer(with data: [Fruit: Int]) {
         fruitContainer = data
     }
     

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -8,15 +8,28 @@ import Foundation
 
 final class FruitStore {
     
-    static let shared = FruitStore()
+    // MARK: Properties
+    private var fruitContainer: [Fruit: Int]
     
-    var fruitContainer: [Fruit: Int] = [
-        .strawberry: 10,
-        .banana: 10,
-        .kiwi: 10,
-        .pineapple: 10,
-        .mango: 10,
-    ]
+    // MARK: Initializer
+    init(fruitContainer: [Fruit: Int]) {
+        self.fruitContainer = fruitContainer
+    }
     
-    private init() {}
+    // MARK: Custom Methods
+    func fetchFruitContainer() -> [Fruit: Int] {
+        return fruitContainer
+    }
+    
+    func fetchFruitQuantity(of fruit: Fruit) -> Int {
+        return fruitContainer[fruit, default: 0] 
+    }
+    
+    func updateFruitContainer(_ data: [Fruit: Int]) {
+        fruitContainer = data
+    }
+    
+    func updateFruitQuantity(of fruit: Fruit, by quantity: Int) {
+        fruitContainer[fruit] = quantity
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -12,7 +12,7 @@ struct JuiceMaker {
     private let fruitStore: FruitStore
     
     // MARK: Initializer
-    init(fruitStore: FruitStore = FruitStore.shared) {
+    init(fruitStore: FruitStore) {
         self.fruitStore = fruitStore
     }
     
@@ -21,20 +21,18 @@ struct JuiceMaker {
     /// 쥬스 제조 메서드
     func makeJuice(juiceType: Juice) throws {
         let dic = juiceType.requiredFruitQuantity
-        let originalFruitContainer = fruitStore.fruitContainer
+        let originalFruitContainer = fruitStore.fetchFruitContainer()
         
         for (fruit, quantity) in dic {
-            guard var storedFruit = fruitStore.fruitContainer[fruit] else {
-                return
-            }
+            var storedFruit = fruitStore.fetchFruitQuantity(of: fruit)
             
             if storedFruit < quantity {
-                fruitStore.fruitContainer = originalFruitContainer
+                fruitStore.updateFruitContainer(originalFruitContainer)
                 throw JuiceMakerError.invalidRequest
             }
             
             storedFruit -= quantity
-            fruitStore.fruitContainer[fruit] = storedFruit
+            fruitStore.updateFruitQuantity(of: fruit, by: storedFruit)
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -24,7 +24,7 @@ struct JuiceMaker {
         let originalFruitContainer = fruitStore.checkFruitContainer()
         
         for (fruit, requiredQuantity) in dic {
-            var remainingQuantity = fruitStore.checkFruitQuantity(of: fruit)
+            var remainingQuantity = fruitStore.quantity(of: fruit)
             
             if remainingQuantity < requiredQuantity {
                 fruitStore.updateFruitContainer(with: originalFruitContainer)

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -21,18 +21,18 @@ struct JuiceMaker {
     /// 쥬스 제조 메서드
     func makeJuice(juiceType: Juice) throws {
         let dic = juiceType.requiredFruitQuantity
-        let originalFruitContainer = fruitStore.fetchFruitContainer()
+        let originalFruitContainer = fruitStore.checkFruitContainer()
         
-        for (fruit, quantity) in dic {
-            var storedFruit = fruitStore.fetchFruitQuantity(of: fruit)
+        for (fruit, requiredQuantity) in dic {
+            var remainingQuantity = fruitStore.checkFruitQuantity(of: fruit)
             
-            if storedFruit < quantity {
-                fruitStore.updateFruitContainer(originalFruitContainer)
+            if remainingQuantity < requiredQuantity {
+                fruitStore.updateFruitContainer(with: originalFruitContainer)
                 throw JuiceMakerError.invalidRequest
             }
             
-            storedFruit -= quantity
-            fruitStore.updateFruitQuantity(of: fruit, by: storedFruit)
+            remainingQuantity -= requiredQuantity
+            fruitStore.updateFruitQuantity(of: fruit, by: remainingQuantity)
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -12,7 +12,7 @@ struct JuiceMaker {
     private let fruitStore: FruitStore
     
     // MARK: Initializer
-    init(fruitStore: FruitStore = FruitStore.shared, counter: Int = 0) {
+    init(fruitStore: FruitStore = FruitStore.shared) {
         self.fruitStore = fruitStore
     }
     

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -19,19 +19,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="16" y="98.999999999999986" width="812" height="136.66666666666663"/>
+                                <rect key="frame" x="63" y="79.999999999999986" width="718" height="136.66666666666663"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="136.66666666666666"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -40,16 +40,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="165.66666666666669" y="0.0" width="149.66666666666669" height="136.66666666666666"/>
+                                        <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -58,16 +58,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="331.33333333333331" y="0.0" width="149.33333333333331" height="136.66666666666666"/>
+                                        <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="149.33333333333334" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.33333333333334" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -76,16 +76,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="496.66666666666669" y="0.0" width="149.66666666666669" height="136.66666666666666"/>
+                                        <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -94,16 +94,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="662.33333333333337" y="0.0" width="149.66666666666663" height="136.66666666666666"/>
+                                        <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -114,13 +114,13 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="16" y="255.66666666666666" width="812" height="80.333333333333343"/>
+                                <rect key="frame" x="63" y="236.66666666666666" width="718" height="112.33333333333334"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="812" height="36"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="718" height="52"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="315.33333333333331" height="36"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="277.66666666666669" height="52"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="딸바쥬스 주문">
@@ -131,11 +131,11 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
-                                                <rect key="frame" x="331.33333333333331" y="0.0" width="149.33333333333331" height="36"/>
+                                                <rect key="frame" x="293.66666666666669" y="0.0" width="142.66666666666669" height="52"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="496.66666666666663" y="0.0" width="315.33333333333337" height="36"/>
+                                                <rect key="frame" x="452.33333333333337" y="0.0" width="265.66666666666663" height="52"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
@@ -148,13 +148,13 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="44.000000000000028" width="812" height="36.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="60.000000000000028" width="718" height="52.333333333333343"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="812" height="36.333333333333336"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
+                                                <rect key="frame" x="0.0" y="0.0" width="718" height="52.333333333333336"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="36.333333333333336"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="127.33333333333333" height="52.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="딸기쥬스 주문">
@@ -165,7 +165,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="165.66666666666669" y="0.0" width="149.66666666666669" height="36.333333333333336"/>
+                                                        <rect key="frame" x="131.33333333333331" y="0.0" width="146.33333333333331" height="52.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="바나나쥬스 주문">
@@ -175,8 +175,8 @@
                                                             <action selector="tapMakeJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Fjk-wy-Ght"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
-                                                        <rect key="frame" x="331.33333333333331" y="0.0" width="149.33333333333331" height="36.333333333333336"/>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA" userLabel="파인애플 쥬스 주문">
+                                                        <rect key="frame" x="281.66666666666669" y="0.0" width="166.66666666666669" height="52.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="파인애플쥬스 주문">
@@ -187,7 +187,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="496.66666666666669" y="0.0" width="149.66666666666669" height="36.333333333333336"/>
+                                                        <rect key="frame" x="452.33333333333331" y="0.0" width="127.33333333333331" height="52.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="키위쥬스 주문">
@@ -198,7 +198,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                        <rect key="frame" x="662.33333333333337" y="0.0" width="149.66666666666663" height="36.333333333333336"/>
+                                                        <rect key="frame" x="583.66666666666663" y="0.0" width="134.33333333333337" height="52.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="망고쥬스 주문">
@@ -219,6 +219,34 @@
                                     <constraint firstItem="ngP-kF-Yii" firstAttribute="trailing" secondItem="q6G-4X-bVm" secondAttribute="trailing" id="IRM-sD-zPp"/>
                                 </constraints>
                             </stackView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gBx-vq-Fgm">
+                                <rect key="frame" x="0.0" y="0.0" width="844" height="60"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="맛있는 쥬스를 만들어 드려요!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fxo-0P-cKH">
+                                        <rect key="frame" x="286" y="15.666666666666666" width="272" height="28.666666666666671"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="24"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2m6-4h-O44">
+                                        <rect key="frame" x="726.66666666666663" y="13" width="87.333333333333371" height="34.333333333333336"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="재고 수정"/>
+                                        <connections>
+                                            <action selector="tapEditInventoryButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="7hJ-l3-7NO"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="60" id="0ta-Ks-tG8"/>
+                                    <constraint firstItem="fxo-0P-cKH" firstAttribute="centerX" secondItem="gBx-vq-Fgm" secondAttribute="centerX" id="CiO-S0-icC"/>
+                                    <constraint firstItem="2m6-4h-O44" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="fxo-0P-cKH" secondAttribute="trailing" constant="100" id="ErJ-Q7-no5"/>
+                                    <constraint firstAttribute="trailing" secondItem="2m6-4h-O44" secondAttribute="trailing" constant="30" id="XbL-Ar-Lwn"/>
+                                    <constraint firstItem="fxo-0P-cKH" firstAttribute="centerY" secondItem="gBx-vq-Fgm" secondAttribute="centerY" id="bg5-hr-5A6"/>
+                                    <constraint firstItem="2m6-4h-O44" firstAttribute="centerY" secondItem="gBx-vq-Fgm" secondAttribute="centerY" id="fSu-EE-WpM"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -226,21 +254,21 @@
                             <constraint firstItem="vaj-6k-c2D" firstAttribute="leading" secondItem="zaq-m5-IIF" secondAttribute="leading" id="4Ki-Xs-fjI"/>
                             <constraint firstItem="zaq-m5-IIF" firstAttribute="height" secondItem="8bC-Xf-vdC" secondAttribute="height" multiplier="35%" id="5ly-0F-l0U"/>
                             <constraint firstItem="Pnn-0B-qbM" firstAttribute="trailing" secondItem="dgU-OE-25m" secondAttribute="trailing" id="6U9-bI-g7g"/>
+                            <constraint firstAttribute="trailing" secondItem="gBx-vq-Fgm" secondAttribute="trailing" id="7fi-px-LmD"/>
+                            <constraint firstItem="gBx-vq-Fgm" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="8rx-fs-y5K"/>
                             <constraint firstItem="hrc-2F-fzl" firstAttribute="trailing" secondItem="G4B-kp-2Jo" secondAttribute="trailing" id="JP9-5g-NDg"/>
+                            <constraint firstItem="gBx-vq-Fgm" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="Tw0-JM-z36"/>
                             <constraint firstItem="zaq-m5-IIF" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="Vlw-OR-dfY"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="vaj-6k-c2D" secondAttribute="bottom" constant="20" id="ea1-Np-zdi"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="zaq-m5-IIF" secondAttribute="trailing" constant="16" id="f8U-FF-gSK"/>
                             <constraint firstItem="vaj-6k-c2D" firstAttribute="trailing" secondItem="zaq-m5-IIF" secondAttribute="trailing" id="fHg-kF-51g"/>
                             <constraint firstItem="vaj-6k-c2D" firstAttribute="top" secondItem="zaq-m5-IIF" secondAttribute="bottom" constant="20" id="lUh-rF-xWP"/>
-                            <constraint firstItem="zaq-m5-IIF" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="20" id="wst-Au-sZB"/>
+                            <constraint firstItem="zaq-m5-IIF" firstAttribute="top" secondItem="gBx-vq-Fgm" secondAttribute="bottom" constant="20" id="roS-bd-KQj"/>
+                            <constraint firstItem="zaq-m5-IIF" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="80" id="wst-Au-sZB"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
-                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
-                            <connections>
-                                <action selector="tapEditInventoryButton:" destination="BYZ-38-t0r" id="GvR-fX-NgF"/>
-                            </connections>
-                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT"/>
                     </navigationItem>
                     <connections>
                         <outlet property="bananaQuantityLabel" destination="gvk-pA-Lw5" id="I0i-ig-edf"/>
@@ -252,25 +280,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="739" y="92"/>
-        </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="LzN-aE-P5w">
-            <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DCG-dP-Fms" sceneMemberID="viewController">
-                    <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="wpg-nM-F9y">
-                        <rect key="frame" x="0.0" y="47" width="844" height="32"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <nil name="viewControllers"/>
-                    <connections>
-                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="AmB-GK-67P"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="66L-FI-VI3" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
+            <point key="canvasLocation" x="738.62559241706163" y="90.769230769230759"/>
         </scene>
         <!--Inventory View Controller-->
         <scene sceneID="fkG-vv-hpE">
@@ -281,136 +291,188 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="88c-7u-0S3">
-                                <rect key="frame" x="107" y="114" width="630" height="162"/>
+                                <rect key="frame" x="107" y="90" width="630" height="249"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="E5h-m1-ct6">
-                                        <rect key="frame" x="0.0" y="0.0" width="94" height="162"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="E5h-m1-ct6">
+                                        <rect key="frame" x="0.0" y="0.0" width="94" height="249"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                                <rect key="frame" x="9.6666666666666714" y="0.0" width="75.000000000000014" height="83.666666666666671"/>
+                                                <rect key="frame" x="9.6666666666666714" y="0.0" width="75" height="128.66666666666666"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                                <rect key="frame" x="40.333333333333343" y="93.666666666666657" width="13.333333333333336" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="138.66666666666666" width="94" height="28.666666666666657"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="177.33333333333331" width="94" height="71.666666666666686"/>
                                                 <connections>
                                                     <action selector="tapStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="nv1-8X-Omw"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="0yV-kn-zaT" firstAttribute="width" secondItem="ZQk-f4-zrz" secondAttribute="width" id="Kaa-IN-dFj"/>
+                                            <constraint firstItem="0yV-kn-zaT" firstAttribute="height" secondItem="ZQk-f4-zrz" secondAttribute="height" multiplier="0.4" id="zdz-Xy-CuX"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="aU8-eN-YVM">
-                                        <rect key="frame" x="134" y="0.0" width="94" height="162"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="aU8-eN-YVM">
+                                        <rect key="frame" x="134" y="0.0" width="94" height="249"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                                <rect key="frame" x="9.6666666666666572" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="9.6666666666666572" y="0.0" width="75" height="128.66666666666666"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                                <rect key="frame" x="40.333333333333314" y="93.666666666666657" width="13.333333333333336" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="138.66666666666666" width="94" height="28.666666666666657"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="177.33333333333331" width="94" height="71.666666666666686"/>
                                                 <connections>
                                                     <action selector="tapStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="zWR-3h-WOS"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="gKu-86-RhI" firstAttribute="height" secondItem="O5s-2N-3iP" secondAttribute="height" multiplier="0.4" id="21R-Mm-zgG"/>
+                                            <constraint firstItem="gKu-86-RhI" firstAttribute="width" secondItem="O5s-2N-3iP" secondAttribute="width" id="cF7-BW-DN9"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Cur-Ul-zXl">
-                                        <rect key="frame" x="268" y="0.0" width="94" height="162"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Cur-Ul-zXl">
+                                        <rect key="frame" x="268" y="0.0" width="94" height="249"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                                <rect key="frame" x="9.6666666666666856" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="9.6666666666666856" y="0.0" width="75" height="128.66666666666666"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                                <rect key="frame" x="40.333333333333314" y="93.666666666666657" width="13.333333333333336" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="138.66666666666666" width="94" height="28.666666666666657"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="177.33333333333331" width="94" height="71.666666666666686"/>
                                                 <connections>
                                                     <action selector="tapStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="5K5-jk-tdp"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="MpT-VW-hCb" firstAttribute="height" secondItem="Rcr-xr-eqz" secondAttribute="height" multiplier="0.4" id="76p-mU-lJi"/>
+                                            <constraint firstItem="MpT-VW-hCb" firstAttribute="width" secondItem="Rcr-xr-eqz" secondAttribute="width" id="wMG-eO-lvI"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="sSW-TW-5vr">
-                                        <rect key="frame" x="402" y="0.0" width="94" height="162"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="sSW-TW-5vr">
+                                        <rect key="frame" x="402" y="0.0" width="94" height="249"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                                <rect key="frame" x="9.6666666666666288" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="9.6666666666666288" y="0.0" width="75" height="128.66666666666666"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                                <rect key="frame" x="40.333333333333371" y="93.666666666666657" width="13.333333333333336" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="138.66666666666666" width="94" height="28.666666666666657"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="177.33333333333331" width="94" height="71.666666666666686"/>
                                                 <connections>
                                                     <action selector="tapStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="WYS-mI-VUz"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="ZDv-1m-HBY" firstAttribute="width" secondItem="klA-59-Nu4" secondAttribute="width" id="5OE-DT-DxL"/>
+                                            <constraint firstItem="ZDv-1m-HBY" firstAttribute="height" secondItem="klA-59-Nu4" secondAttribute="height" multiplier="0.4" id="bYa-uU-JcD"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="OeC-fi-47F">
-                                        <rect key="frame" x="536" y="0.0" width="94" height="162"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="OeC-fi-47F">
+                                        <rect key="frame" x="536" y="0.0" width="94" height="249"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                                <rect key="frame" x="9.6666666666666288" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="9.6666666666666288" y="0.0" width="75" height="128.66666666666666"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                                <rect key="frame" x="40.333333333333371" y="93.666666666666657" width="13.333333333333336" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="138.66666666666666" width="94" height="28.666666666666657"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="177.33333333333331" width="94" height="71.666666666666686"/>
                                                 <connections>
                                                     <action selector="tapStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="cTe-Hs-92N"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="YJI-ER-LJR" firstAttribute="height" secondItem="xbn-6P-grO" secondAttribute="height" multiplier="0.4" id="10x-yN-yfE"/>
+                                            <constraint firstItem="YJI-ER-LJR" firstAttribute="width" secondItem="xbn-6P-grO" secondAttribute="width" id="EC7-za-2Lx"/>
+                                        </constraints>
                                     </stackView>
                                 </subviews>
                             </stackView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CxM-ct-nvb">
+                                <rect key="frame" x="0.0" y="0.0" width="844" height="60"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yCJ-eV-ASV">
+                                        <rect key="frame" x="760.33333333333337" y="13" width="53.666666666666629" height="34.333333333333336"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="닫기"/>
+                                        <connections>
+                                            <action selector="tapCloseInventoryButton:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="K0g-hx-ivz"/>
+                                        </connections>
+                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="재고 추가" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kBr-lJ-Eaq">
+                                        <rect key="frame" x="377.66666666666669" y="13.333333333333334" width="88.666666666666686" height="28.666666666666664"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="24"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="yCJ-eV-ASV" secondAttribute="trailing" constant="30" id="Mti-fJ-8gc"/>
+                                    <constraint firstItem="yCJ-eV-ASV" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="kBr-lJ-Eaq" secondAttribute="trailing" constant="100" id="S9M-DR-Rrv"/>
+                                    <constraint firstItem="kBr-lJ-Eaq" firstAttribute="centerY" secondItem="CxM-ct-nvb" secondAttribute="centerY" constant="-2.5000000000000249" id="cWM-K4-ey4"/>
+                                    <constraint firstItem="kBr-lJ-Eaq" firstAttribute="centerX" secondItem="CxM-ct-nvb" secondAttribute="centerX" id="jvF-zM-ict"/>
+                                    <constraint firstAttribute="height" constant="60" id="tgP-TU-kel"/>
+                                    <constraint firstItem="yCJ-eV-ASV" firstAttribute="centerY" secondItem="CxM-ct-nvb" secondAttribute="centerY" id="yfF-lC-TRb"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="88c-7u-0S3" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="JzW-6e-zk3"/>
-                            <constraint firstItem="88c-7u-0S3" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="OFj-Y7-R4V"/>
+                            <constraint firstAttribute="trailing" secondItem="CxM-ct-nvb" secondAttribute="trailing" id="Aay-eA-3Mn"/>
+                            <constraint firstItem="88c-7u-0S3" firstAttribute="centerX" secondItem="gcO-Xb-kNs" secondAttribute="centerX" id="CSH-7w-gyx"/>
+                            <constraint firstItem="CxM-ct-nvb" firstAttribute="top" secondItem="gcO-Xb-kNs" secondAttribute="top" id="IXp-A6-5DI"/>
+                            <constraint firstItem="88c-7u-0S3" firstAttribute="top" secondItem="CxM-ct-nvb" secondAttribute="bottom" constant="30" id="Svc-Tf-ZJJ"/>
+                            <constraint firstItem="CxM-ct-nvb" firstAttribute="leading" secondItem="tKV-4l-Vtc" secondAttribute="leading" id="kLk-wT-gxY"/>
+                            <constraint firstItem="gcO-Xb-kNs" firstAttribute="bottom" secondItem="88c-7u-0S3" secondAttribute="bottom" constant="30" id="pqo-mV-9uh"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
@@ -440,7 +502,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGray5Color">
-            <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -19,19 +19,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="63" y="79.999999999999986" width="718" height="136.66666666666663"/>
+                                <rect key="frame" x="16" y="126.99999999999999" width="812" height="136.66666666666663"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="136.66666666666666"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -40,16 +40,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="136.66666666666666"/>
+                                        <rect key="frame" x="165.66666666666669" y="0.0" width="149.66666666666669" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -58,16 +58,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="136.66666666666666"/>
+                                        <rect key="frame" x="331.33333333333331" y="0.0" width="149.33333333333331" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="149.33333333333334" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.33333333333334" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -76,16 +76,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="136.66666666666666"/>
+                                        <rect key="frame" x="496.66666666666669" y="0.0" width="149.66666666666669" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -94,16 +94,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="136.66666666666666"/>
+                                        <rect key="frame" x="662.33333333333337" y="0.0" width="149.66666666666663" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -114,13 +114,13 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="63" y="236.66666666666666" width="718" height="112.33333333333334"/>
+                                <rect key="frame" x="16" y="283.66666666666669" width="812" height="52.333333333333314"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="718" height="52"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="812" height="22"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="277.66666666666669" height="52"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="315.33333333333331" height="22"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="딸바쥬스 주문">
@@ -131,11 +131,11 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
-                                                <rect key="frame" x="293.66666666666669" y="0.0" width="142.66666666666669" height="52"/>
+                                                <rect key="frame" x="331.33333333333331" y="0.0" width="164.66666666666669" height="22"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="452.33333333333337" y="0.0" width="265.66666666666663" height="52"/>
+                                                <rect key="frame" x="512" y="0.0" width="300" height="22"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
@@ -148,13 +148,13 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="60.000000000000028" width="718" height="52.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="30" width="812" height="22.333333333333329"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="718" height="52.333333333333336"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="812" height="22.333333333333332"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="127.33333333333333" height="52.333333333333336"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="144" height="22.333333333333332"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="딸기쥬스 주문">
@@ -165,7 +165,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="131.33333333333331" y="0.0" width="146.33333333333331" height="52.333333333333336"/>
+                                                        <rect key="frame" x="148" y="0.0" width="167.33333333333337" height="22.333333333333332"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="바나나쥬스 주문">
@@ -176,7 +176,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA" userLabel="파인애플 쥬스 주문">
-                                                        <rect key="frame" x="281.66666666666669" y="0.0" width="166.66666666666669" height="52.333333333333336"/>
+                                                        <rect key="frame" x="319.33333333333331" y="0.0" width="188.66666666666669" height="22.333333333333332"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="파인애플쥬스 주문">
@@ -187,7 +187,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="452.33333333333331" y="0.0" width="127.33333333333331" height="52.333333333333336"/>
+                                                        <rect key="frame" x="512" y="0.0" width="143.66666666666663" height="22.333333333333332"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="키위쥬스 주문">
@@ -198,7 +198,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                        <rect key="frame" x="583.66666666666663" y="0.0" width="134.33333333333337" height="52.333333333333336"/>
+                                                        <rect key="frame" x="659.66666666666663" y="0.0" width="152.33333333333337" height="22.333333333333332"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="망고쥬스 주문">
@@ -220,7 +220,7 @@
                                 </constraints>
                             </stackView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gBx-vq-Fgm">
-                                <rect key="frame" x="0.0" y="0.0" width="844" height="60"/>
+                                <rect key="frame" x="0.0" y="47" width="844" height="60"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="맛있는 쥬스를 만들어 드려요!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fxo-0P-cKH">
                                         <rect key="frame" x="286" y="15.666666666666666" width="272" height="28.666666666666671"/>
@@ -291,26 +291,26 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="88c-7u-0S3">
-                                <rect key="frame" x="107" y="90" width="630" height="249"/>
+                                <rect key="frame" x="107" y="137" width="630" height="189"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="E5h-m1-ct6">
-                                        <rect key="frame" x="0.0" y="0.0" width="94" height="249"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="94" height="189"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                                <rect key="frame" x="9.6666666666666714" y="0.0" width="75" height="128.66666666666666"/>
+                                                <rect key="frame" x="9.6666666666666714" y="0.0" width="75" height="97.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                                <rect key="frame" x="0.0" y="138.66666666666666" width="94" height="28.666666666666657"/>
+                                                <rect key="frame" x="0.0" y="107.66666666666666" width="94" height="20.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                                <rect key="frame" x="0.0" y="177.33333333333331" width="94" height="71.666666666666686"/>
+                                                <rect key="frame" x="0.0" y="138" width="94" height="51"/>
                                                 <connections>
                                                     <action selector="tapStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="nv1-8X-Omw"/>
                                                 </connections>
@@ -322,23 +322,23 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="aU8-eN-YVM">
-                                        <rect key="frame" x="134" y="0.0" width="94" height="249"/>
+                                        <rect key="frame" x="134" y="0.0" width="94" height="189"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                                <rect key="frame" x="9.6666666666666572" y="0.0" width="75" height="128.66666666666666"/>
+                                                <rect key="frame" x="9.6666666666666572" y="0.0" width="75" height="97.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                                <rect key="frame" x="0.0" y="138.66666666666666" width="94" height="28.666666666666657"/>
+                                                <rect key="frame" x="0.0" y="107.66666666666666" width="94" height="20.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                                <rect key="frame" x="0.0" y="177.33333333333331" width="94" height="71.666666666666686"/>
+                                                <rect key="frame" x="0.0" y="138" width="94" height="51"/>
                                                 <connections>
                                                     <action selector="tapStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="zWR-3h-WOS"/>
                                                 </connections>
@@ -350,23 +350,23 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Cur-Ul-zXl">
-                                        <rect key="frame" x="268" y="0.0" width="94" height="249"/>
+                                        <rect key="frame" x="268" y="0.0" width="94" height="189"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                                <rect key="frame" x="9.6666666666666856" y="0.0" width="75" height="128.66666666666666"/>
+                                                <rect key="frame" x="9.6666666666666856" y="0.0" width="75" height="97.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                                <rect key="frame" x="0.0" y="138.66666666666666" width="94" height="28.666666666666657"/>
+                                                <rect key="frame" x="0.0" y="107.66666666666666" width="94" height="20.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                                <rect key="frame" x="0.0" y="177.33333333333331" width="94" height="71.666666666666686"/>
+                                                <rect key="frame" x="0.0" y="138" width="94" height="51"/>
                                                 <connections>
                                                     <action selector="tapStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="5K5-jk-tdp"/>
                                                 </connections>
@@ -378,23 +378,23 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="sSW-TW-5vr">
-                                        <rect key="frame" x="402" y="0.0" width="94" height="249"/>
+                                        <rect key="frame" x="402" y="0.0" width="94" height="189"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                                <rect key="frame" x="9.6666666666666288" y="0.0" width="75" height="128.66666666666666"/>
+                                                <rect key="frame" x="9.6666666666666288" y="0.0" width="75" height="97.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                                <rect key="frame" x="0.0" y="138.66666666666666" width="94" height="28.666666666666657"/>
+                                                <rect key="frame" x="0.0" y="107.66666666666666" width="94" height="20.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                                <rect key="frame" x="0.0" y="177.33333333333331" width="94" height="71.666666666666686"/>
+                                                <rect key="frame" x="0.0" y="138" width="94" height="51"/>
                                                 <connections>
                                                     <action selector="tapStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="WYS-mI-VUz"/>
                                                 </connections>
@@ -406,23 +406,23 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="OeC-fi-47F">
-                                        <rect key="frame" x="536" y="0.0" width="94" height="249"/>
+                                        <rect key="frame" x="536" y="0.0" width="94" height="189"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                                <rect key="frame" x="9.6666666666666288" y="0.0" width="75" height="128.66666666666666"/>
+                                                <rect key="frame" x="9.6666666666666288" y="0.0" width="75" height="97.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                                <rect key="frame" x="0.0" y="138.66666666666666" width="94" height="28.666666666666657"/>
+                                                <rect key="frame" x="0.0" y="107.66666666666666" width="94" height="20.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                                <rect key="frame" x="0.0" y="177.33333333333331" width="94" height="71.666666666666686"/>
+                                                <rect key="frame" x="0.0" y="138" width="94" height="51"/>
                                                 <connections>
                                                     <action selector="tapStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="cTe-Hs-92N"/>
                                                 </connections>
@@ -436,7 +436,7 @@
                                 </subviews>
                             </stackView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CxM-ct-nvb">
-                                <rect key="frame" x="0.0" y="0.0" width="844" height="60"/>
+                                <rect key="frame" x="0.0" y="47" width="844" height="60"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yCJ-eV-ASV">
                                         <rect key="frame" x="760.33333333333337" y="13" width="53.666666666666629" height="34.333333333333336"/>
@@ -447,7 +447,7 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="재고 추가" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kBr-lJ-Eaq">
-                                        <rect key="frame" x="377.66666666666669" y="13.333333333333334" width="88.666666666666686" height="28.666666666666664"/>
+                                        <rect key="frame" x="377.66666666666669" y="15.666666666666666" width="88.666666666666686" height="28.666666666666671"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="24"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -457,7 +457,7 @@
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="yCJ-eV-ASV" secondAttribute="trailing" constant="30" id="Mti-fJ-8gc"/>
                                     <constraint firstItem="yCJ-eV-ASV" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="kBr-lJ-Eaq" secondAttribute="trailing" constant="100" id="S9M-DR-Rrv"/>
-                                    <constraint firstItem="kBr-lJ-Eaq" firstAttribute="centerY" secondItem="CxM-ct-nvb" secondAttribute="centerY" constant="-2.5000000000000249" id="cWM-K4-ey4"/>
+                                    <constraint firstItem="kBr-lJ-Eaq" firstAttribute="centerY" secondItem="CxM-ct-nvb" secondAttribute="centerY" id="cWM-K4-ey4"/>
                                     <constraint firstItem="kBr-lJ-Eaq" firstAttribute="centerX" secondItem="CxM-ct-nvb" secondAttribute="centerX" id="jvF-zM-ict"/>
                                     <constraint firstAttribute="height" constant="60" id="tgP-TU-kel"/>
                                     <constraint firstItem="yCJ-eV-ASV" firstAttribute="centerY" secondItem="CxM-ct-nvb" secondAttribute="centerY" id="yfF-lC-TRb"/>
@@ -502,7 +502,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGray5Color">
-            <color red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
@@ -39,12 +39,15 @@ final class InventoryViewController: UIViewController {
         mangoStepper: (mangoQuantityLabel, .mango)
     ]
     
-    // MARK: Initializer
-    required init?(coder aDecoder: NSCoder) {
-        self.fruitStore = FruitStore.init(fruitContainer: [:])
+    init?(coder aDecoder: NSCoder, fruitStore: FruitStore) {
+        self.fruitStore = fruitStore
         super.init(coder: aDecoder)
     }
-
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     // MARK: Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
@@ -55,7 +55,7 @@ final class InventoryViewController: UIViewController {
         configureUI()
     }
     
-    @IBAction func tapCloseInventoryButton(_ sender: UIButton) {
+    @IBAction private func tapCloseInventoryButton(_ sender: UIButton) {
         guard let presentingViewController = presentingViewController as? OrderViewController else {
             return
         }
@@ -64,7 +64,7 @@ final class InventoryViewController: UIViewController {
         self.dismiss(animated: true)
     }
     
-    @IBAction func tapStepper(_ sender: UIStepper) {
+    @IBAction private func tapStepper(_ sender: UIStepper) {
         guard let fruit = fruitElementsByStepper[sender]?.fruit else {
             return
         }
@@ -77,7 +77,6 @@ extension InventoryViewController {
     
     private func configureUI() {
         for (fruit, components) in componentsByFruit {
-            let fruitQuantity: Int = fruitStore.checkFruitQuantity(of: fruit)
             components.label.text = String(fruitQuantity)
             components.stepper.value = Double(fruitQuantity)
         }

--- a/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
@@ -52,6 +52,10 @@ final class InventoryViewController: UIViewController {
         configureUI()
     }
     
+    @IBAction func tapCloseInventoryButton(_ sender: UIButton) {
+        self.dismiss(animated: true)
+    }
+    
     @IBAction func tapStepper(_ sender: UIStepper) {
         guard let fruit = fruitElementsByStepper[sender]?.fruit else {
             return

--- a/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
@@ -22,7 +22,7 @@ final class InventoryViewController: UIViewController {
     @IBOutlet private weak var mangoStepper: UIStepper!
     
     // MARK: Properties
-    private var fruitStore: FruitStore
+    private let fruitStore: FruitStore = FruitStore(fruitContainer: [:])
     private lazy var componentsByFruit: [Fruit: (label: UILabel, stepper: UIStepper)] = [
         .strawberry: (strawberryQuantityLabel, strawberryStepper),
         .banana: (bananaQuantityLabel, bananaStepper),
@@ -38,13 +38,7 @@ final class InventoryViewController: UIViewController {
         kiwiStepper: (kiwiQuantityLabel, .kiwi),
         mangoStepper: (mangoQuantityLabel, .mango)
     ]
-    
-    // MARK: Initializer
-    required init?(coder aDecoder: NSCoder) {
-        self.fruitStore = FruitStore.shared
-        super.init(coder: aDecoder)
-    }
-    
+
     // MARK: Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -53,6 +47,10 @@ final class InventoryViewController: UIViewController {
     }
     
     @IBAction func tapCloseInventoryButton(_ sender: UIButton) {
+        guard let presentingViewController = presentingViewController as? OrderViewController else {
+            return
+        }
+        presentingViewController.setUpFruitContainer(data: fruitStore.fetchFruitContainer())
         self.dismiss(animated: true)
     }
     
@@ -69,14 +67,19 @@ extension InventoryViewController {
     
     private func configureUI() {
         for (fruit, components) in componentsByFruit {
-            let fruitQuantity: Int = fruitStore.fruitContainer[fruit, default: 0]
+            let fruitQuantity: Int = fruitStore.fetchFruitQuantity(of: fruit)
             components.label.text = String(fruitQuantity)
             components.stepper.value = Double(fruitQuantity)
         }
     }
     
     private func updateFruitQuantity(_ stepper: UIStepper, _ fruit: Fruit) {
-        fruitElementsByStepper[stepper]?.label.text = String(Int(stepper.value))
-        fruitStore.fruitContainer[fruit] = Int(stepper.value)
+        let fruitQuantity = Int(stepper.value)
+        fruitElementsByStepper[stepper]?.label.text = String(fruitQuantity)
+        fruitStore.updateFruitQuantity(of: fruit, by: fruitQuantity)
+    }
+    
+    func setUpFruitContainerData(_ data: [Fruit: Int]) {
+        fruitStore.updateFruitContainer(data)
     }
 }

--- a/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
@@ -88,8 +88,4 @@ extension InventoryViewController {
         fruitElementsByStepper[stepper]?.label.text = String(fruitQuantity)
         fruitStore.updateFruitQuantity(of: fruit, by: fruitQuantity)
     }
-    
-    func setUpFruitContainer(data: [Fruit: Int]) {
-        fruitStore.updateFruitContainer(with: data)
-    }
 }

--- a/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
@@ -77,6 +77,7 @@ extension InventoryViewController {
     
     private func configureUI() {
         for (fruit, components) in componentsByFruit {
+            let fruitQuantity: Int = fruitStore.quantity(of: fruit)
             components.label.text = String(fruitQuantity)
             components.stepper.value = Double(fruitQuantity)
         }

--- a/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
@@ -50,7 +50,8 @@ final class InventoryViewController: UIViewController {
         guard let presentingViewController = presentingViewController as? OrderViewController else {
             return
         }
-        presentingViewController.setUpFruitContainer(data: fruitStore.fetchFruitContainer())
+        let fruitInventory = fruitStore.checkFruitContainer()
+        presentingViewController.setUpFruitContainer(data: fruitInventory)
         self.dismiss(animated: true)
     }
     
@@ -67,7 +68,7 @@ extension InventoryViewController {
     
     private func configureUI() {
         for (fruit, components) in componentsByFruit {
-            let fruitQuantity: Int = fruitStore.fetchFruitQuantity(of: fruit)
+            let fruitQuantity: Int = fruitStore.checkFruitQuantity(of: fruit)
             components.label.text = String(fruitQuantity)
             components.stepper.value = Double(fruitQuantity)
         }
@@ -79,7 +80,7 @@ extension InventoryViewController {
         fruitStore.updateFruitQuantity(of: fruit, by: fruitQuantity)
     }
     
-    func setUpFruitContainerData(_ data: [Fruit: Int]) {
-        fruitStore.updateFruitContainer(data)
+    func setUpFruitContainer(data: [Fruit: Int]) {
+        fruitStore.updateFruitContainer(with: data)
     }
 }

--- a/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/View/InventoryViewController.swift
@@ -22,7 +22,7 @@ final class InventoryViewController: UIViewController {
     @IBOutlet private weak var mangoStepper: UIStepper!
     
     // MARK: Properties
-    private let fruitStore: FruitStore = FruitStore(fruitContainer: [:])
+    private let fruitStore: FruitStore
     private lazy var componentsByFruit: [Fruit: (label: UILabel, stepper: UIStepper)] = [
         .strawberry: (strawberryQuantityLabel, strawberryStepper),
         .banana: (bananaQuantityLabel, bananaStepper),
@@ -38,6 +38,12 @@ final class InventoryViewController: UIViewController {
         kiwiStepper: (kiwiQuantityLabel, .kiwi),
         mangoStepper: (mangoQuantityLabel, .mango)
     ]
+    
+    // MARK: Initializer
+    required init?(coder aDecoder: NSCoder) {
+        self.fruitStore = FruitStore.init(fruitContainer: [:])
+        super.init(coder: aDecoder)
+    }
 
     // MARK: Life Cycle
     override func viewDidLoad() {


### PR DESCRIPTION
@junbangg
안녕하세요~ 알라딘! Jane, Harry입니다!
STEP 3 마지막 PR 올립니다!!!!!
조언, 제안 모두 환영이니 자유롭게 의견주시면 감사하겠습니다😊😊

## 🔍 What is this PR?
STEP 3의 기능을 구현했습니다.
- 상단바 '재고 추가' 및 '닫기' 버튼 구현
- 화면전환 방식 수정(`Navi 방식` -> `Modality`)
- 데이터 저장 방식 및 전달 방식 수정 (싱글톤 패턴 -> 화면 전환 시 데이터 전달)

## 📝 PR Point
### 상단바 UI 구현 및 오토레이아웃 적용 (아이폰 SE 기기대응)
새롭게 추가된 UI 구현 사항을 구현하며 스토리보드를 이용해 오토레이아웃을 적용해주었고, `Stack View`를 사용해 아이폰 SE 기기의 화면까지 대응할 수 있도록 했습니다.
  
### 화면전환 방식 수정 - Modality
STEP 2 PR에서 고민되는 부분으로 언급했었는데, HIG 문서를 기반으로 고민했을 때 해당 로직에서는 Modality가 더 적합하다고 판단했고,
STEP 3에서 구현 요구 사항으로 추가된 버튼의 타이틀인 '닫기' 라는 단어의 의미도 Modality와 더 어울린다고 생각해서 화면전환 방식을 네비 방식에서 모달 방식으로 수정했습니다.

### 데이터 저장 방식 및 전달 방식 수정
기존 싱글톤 패턴을 이용한 데이터 저장 및 업데이트 로직을 첫번째 화면인 `OrderViewController`에서의 초기값 설정 후 데이터 변경사항을 화면전환 시에 다음 화면, 이전 화면으로 넘겨주는 방식으로 수정했습니다. 

**로직 변경 이유**
해당 프로젝트에서는 2개의 화면만 존재하기 때문에 전역에서 접근할 수 있는 싱글톤 인스턴스를 두는 것보다 화면전환 시 데이터 전달 방식으로 데이터를 다음 화면으로 넘겨주고, 다시 넘겨받는 방식으로 화면에 보이는 UI를 업데이트 해주는 방식이 더 적합하다고 판단했습니다.

데이터를 가져오고 변경해주는 방식을 `FruitStore`의 프로퍼티에 직접 접근하는 방식이 아닌, 프로퍼티는 접근 제어를 통해 클래스 내부로 숨기고 클래스의 메서드에 접근해 가져오고 변경해주는 형태로 구성했습니다. 싱글톤 패턴을 사용했을 때는 앱 전역에서 프로퍼티에 쉽게 접근해 변경할 수 있었기 때문에 데이터의 사용 및 변경이 용이하다는 이점이 있었지만 해당 방식으로 코드를 수정해 데이터를 가지고 있는 프로퍼티를 은닉화해줄 수 있었습니다. 

두가지 방식에 장단점이 있다고 생각하는데, 여기에 대한 리뷰어님의 의견도 궁금합니다!!! 자유롭게 코멘트로 의견 남겨주시면 감사하겠습니다😊😊

## 📸 Screenshot
|    구현 내용    |   구동 영상   |
| :-------------: | :----------: |
| 쥬스 제조 및 재고관리 로직 |  ![Simulator Screen Recording - iPhone 14 Pro - 2023-12-19 at 21 07 32](https://github.com/tasty-code/ios-juice-maker/assets/63277563/2090ad0f-5dc1-4682-befe-350c592e4ac0) |
| SE 기기 대응 | <img width="700" alt="스크린샷 2023-12-19 오후 9 09 20" src="https://github.com/tasty-code/ios-juice-maker/assets/63277563/355a1be0-bd3f-4b4d-9dfc-533c22e99a17"> |
