### PR TITLE
쥬스 자판기 [STEP 3] 노움, 폴

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		89667E162B200A170017C068 /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89667E152B200A170017C068 /* Fruit.swift */; };
 		89667E182B200A880017C068 /* Recipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89667E172B200A880017C068 /* Recipe.swift */; };
 		89687E5D2B31564700C9290F /* StockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89687E5C2B31564700C9290F /* StockViewController.swift */; };
+		89687E802B35449600C9290F /* VCIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89687E7F2B35449600C9290F /* VCIdentifiers.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
@@ -27,6 +28,7 @@
 		89667E152B200A170017C068 /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
 		89667E172B200A880017C068 /* Recipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Recipe.swift; sourceTree = "<group>"; };
 		89687E5C2B31564700C9290F /* StockViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockViewController.swift; sourceTree = "<group>"; };
+		89687E7F2B35449600C9290F /* VCIdentifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VCIdentifiers.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -71,6 +73,7 @@
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
 				89667E152B200A170017C068 /* Fruit.swift */,
 				89667E172B200A880017C068 /* Recipe.swift */,
+				89687E7F2B35449600C9290F /* VCIdentifiers.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -184,6 +187,7 @@
 			files = (
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
 				CCBC29302B294B1F00D75D5E /* AlertManager.swift in Sources */,
+				89687E802B35449600C9290F /* VCIdentifiers.swift in Sources */,
 				C73DAF3B255D0CDD00020D38 /* StoreViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,

--- a/JuiceMaker/JuiceMaker/Controller/AlertManager.swift
+++ b/JuiceMaker/JuiceMaker/Controller/AlertManager.swift
@@ -7,12 +7,13 @@
 
 import UIKit
 struct AlertManager {
+    
     static func setAlert(
         vcToShow: UIViewController?,
         preferredStyle: UIAlertController.Style = .alert,
         title: String = String(),
         message: String = String(),
-        buttonActions: [UIAlertAction]
+        handler: [String : (() -> Void)?] = [:]
     ) {
         guard let currentVC = vcToShow else {
             return
@@ -22,11 +23,19 @@ struct AlertManager {
             message: message,
             preferredStyle: preferredStyle
         )
-        for alertAction in buttonActions {
+        print(handler.keys)
+        handler.forEach { name, action in
+            var alertAction: UIAlertAction
+            if action != nil  {
+                alertAction = UIAlertAction(title: name, style: .default) {_ in
+                    action?()
+                }
+            } else {
+                alertAction = UIAlertAction(title: name, style: .cancel)
+            }
             alert.addAction(alertAction)
         }
         currentVC.present(alert, animated: true, completion: nil)
-        
     }
     
     private func generateAlert(

--- a/JuiceMaker/JuiceMaker/Controller/AlertManager.swift
+++ b/JuiceMaker/JuiceMaker/Controller/AlertManager.swift
@@ -23,7 +23,7 @@ struct AlertManager {
             message: message,
             preferredStyle: preferredStyle
         )
-        print(handler.keys)
+        
         handler.forEach { name, action in
             var alertAction: UIAlertAction
             if action != nil  {

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -66,7 +66,7 @@ final class StockViewController: UIViewController {
         switch sender.tag {
         case 0:
             selectedFruit = Fruit.strawberry
-        case 1: 
+        case 1:
             selectedFruit = Fruit.banana
         case 2:
             selectedFruit = Fruit.pineapple
@@ -83,6 +83,7 @@ final class StockViewController: UIViewController {
             return
         }
         let intSender = Int(sender.value)
+        fruitStore.fruits[selectedFruit.rawValue] = intSender
         setTextView.text = String(intSender)
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -82,8 +82,8 @@ final class StockViewController: UIViewController {
         else {
             return
         }
-        let intSender = Int(sender.value)
-        fruitStore.fruits[selectedFruit.rawValue] = intSender
-        setTextView.text = String(intSender)
+        let updatedFruitsStock = Int(sender.value)
+        fruitStore.fruits[selectedFruit.rawValue] = updatedFruitsStock
+        setTextView.text = String(updatedFruitsStock)
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/StoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StoreViewController.swift
@@ -120,7 +120,7 @@ extension StoreViewController {
                 preferredStyle: UIAlertController.Style.alert,
                 title: "\(recipeName) 쥬스 나왔습니다! 맛있게 드세요!",
                 message: "",
-                buttonActions: [dismissAlertAction]
+                handler: ["확인": nil]
             )
         }
         else {
@@ -129,7 +129,7 @@ extension StoreViewController {
                 preferredStyle: UIAlertController.Style.alert,
                 title: "재료가 모자라요. 재고를 수정할까요?",
                 message: "",
-                buttonActions: [acceptAlertAction, cancelAlertAction]
+                handler: ["예": self.moveFruitStore, "아니오": nil]
             )
         }
     }

--- a/JuiceMaker/JuiceMaker/Controller/StoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StoreViewController.swift
@@ -24,13 +24,6 @@ final class StoreViewController: UIViewController {
     let fruitStore = FruitStore.shared
     lazy var juiceMaker: JuiceMaker = JuiceMaker(store: fruitStore)
     
-    let dismissAlertAction = UIAlertAction(title: "확인", style: .default)
-    lazy var acceptAlertAction = UIAlertAction(title: "예", style: .default) { action in
-        self.moveFruitStore()
-    }
-    let cancelAlertAction = UIAlertAction(title: "아니오", style: .destructive)
-    
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         fruitStore.initializeFruit()

--- a/JuiceMaker/JuiceMaker/Controller/StoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StoreViewController.swift
@@ -65,7 +65,7 @@ final class StoreViewController: UIViewController {
     }
     
     private func moveFruitStore() {
-        guard let secondVC = storyboard?.instantiateViewController(withIdentifier: "StockViewController") as? StockViewController else { return }
+        guard let secondVC = storyboard?.instantiateViewController(withIdentifier: VCIdentifiers.StockViewController.rawValue) as? StockViewController else { return }
         secondVC.modalPresentationStyle = .fullScreen
         self.present(secondVC, animated: true)
     }

--- a/JuiceMaker/JuiceMaker/Controller/StoreViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StoreViewController.swift
@@ -34,13 +34,11 @@ final class StoreViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         fruitStore.initializeFruit()
-        initView()
-        print("test2")
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        print("test1")
+        initView()
     }
     
     @IBAction func moveToFruitStoreBtnTapped(_ sender: Any) {
@@ -74,10 +72,9 @@ final class StoreViewController: UIViewController {
     }
     
     private func moveFruitStore() {
-//        self.performSegue(withIdentifier: "moveToStock", sender: "test")
         guard let secondVC = storyboard?.instantiateViewController(withIdentifier: "StockViewController") as? StockViewController else { return }
         secondVC.modalPresentationStyle = .fullScreen
-        self.present(secondVC, animated: false)
+        self.present(secondVC, animated: true)
     }
     
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -34,16 +34,6 @@ final class FruitStore {
         Recipe.mango.rawValue: [3],
         Recipe.mangoKiwi.rawValue: [2, 1]
     ]
-    /*
-    func supplyFruits(fruitName: String, quantity: Int) throws {
-        guard let currentStock = fruits[fruitName] else {
-            throw JuiceMakerErrors.notEnoughFruits
-        }
-        fruits[fruitName] = currentStock + quantity
-        print("과일 저장소에서 \(fruitName)를 \(quantity)만큼 추가 저장했습니다")
-        print(fruits)
-    }
-     */
     
     func resetFlag() {
         self.fruitsFlag.keys.forEach { fruits in

--- a/JuiceMaker/JuiceMaker/Model/VCIdentifiers.swift
+++ b/JuiceMaker/JuiceMaker/Model/VCIdentifiers.swift
@@ -1,0 +1,8 @@
+//
+//  VCIdentifiers.swift
+//  JuiceMaker
+//
+//  Created by 이보한 on 2023/12/22.
+//
+
+import Foundation

--- a/JuiceMaker/JuiceMaker/Model/VCIdentifiers.swift
+++ b/JuiceMaker/JuiceMaker/Model/VCIdentifiers.swift
@@ -6,3 +6,8 @@
 //
 
 import Foundation
+
+enum VCIdentifiers: String {
+    case StockViewController = "StockViewController"
+    case StoreViewController = "StoreViewController"
+}

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
-    <device id="retina6_12" orientation="landscape" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+    <device id="retina4_7" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -15,23 +15,23 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="StoreViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="852" height="393"/>
+                        <rect key="frame" x="0.0" y="0.0" width="667" height="375"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="75" y="63.999999999999986" width="702" height="137.66666666666663"/>
+                                <rect key="frame" x="16" y="64" width="635" height="131.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="127.66666666666667" height="137.66666666666666"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="114" height="131.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="127.66666666666667" height="103.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="114" height="97"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="111.33333333333334" width="127.66666666666667" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="105" width="114" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -40,16 +40,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="143.66666666666666" y="0.0" width="127.66666666666666" height="137.66666666666666"/>
+                                        <rect key="frame" x="130" y="0.0" width="114.5" height="131.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="127.66666666666667" height="103.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="114.5" height="97"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="111.33333333333334" width="127.66666666666667" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="105" width="114.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -58,16 +58,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="287.33333333333331" y="0.0" width="127.33333333333331" height="137.66666666666666"/>
+                                        <rect key="frame" x="260.5" y="0.0" width="114" height="131.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="127.33333333333333" height="103.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="114" height="97"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="111.33333333333334" width="127.33333333333333" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="105" width="114" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -76,16 +76,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="430.66666666666669" y="0.0" width="127.66666666666669" height="137.66666666666666"/>
+                                        <rect key="frame" x="390.5" y="0.0" width="114.5" height="131.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="127.66666666666667" height="103.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="114.5" height="97"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="111.33333333333334" width="127.66666666666667" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="105" width="114.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -94,16 +94,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="574.33333333333337" y="0.0" width="127.66666666666663" height="137.66666666666666"/>
+                                        <rect key="frame" x="521" y="0.0" width="114" height="131.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="127.66666666666667" height="103.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="114" height="97"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="111.33333333333334" width="127.66666666666667" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="105" width="114" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -114,13 +114,13 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="75" y="221.66666666666663" width="702" height="130.33333333333337"/>
+                                <rect key="frame" x="16" y="215.5" width="635" height="139.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="702" height="61"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="635" height="65.5"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="271.33333333333331" height="61"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="244.5" height="65.5"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="딸바쥬스 주문">
@@ -131,11 +131,11 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
-                                                <rect key="frame" x="287.33333333333331" y="0.0" width="127.33333333333331" height="61"/>
+                                                <rect key="frame" x="260.5" y="0.0" width="114" height="65.5"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
                                             <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="430.66666666666674" y="0.0" width="271.33333333333326" height="61"/>
+                                                <rect key="frame" x="390.5" y="0.0" width="244.5" height="65.5"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
@@ -148,13 +148,13 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="69.000000000000028" width="702" height="61.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="73.5" width="635" height="66"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="702" height="61.333333333333336"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="635" height="66"/>
                                                 <subviews>
                                                     <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="127.66666666666667" height="61.333333333333336"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="114" height="66"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="딸기쥬스 주문">
@@ -165,7 +165,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="143.66666666666666" y="0.0" width="127.66666666666666" height="61.333333333333336"/>
+                                                        <rect key="frame" x="130" y="0.0" width="114.5" height="66"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="바나나쥬스 주문">
@@ -176,7 +176,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
-                                                        <rect key="frame" x="287.33333333333331" y="0.0" width="127.33333333333331" height="61.333333333333336"/>
+                                                        <rect key="frame" x="260.5" y="0.0" width="114" height="66"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="파인애플쥬스 주문">
@@ -187,7 +187,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="430.66666666666669" y="0.0" width="127.66666666666669" height="61.333333333333336"/>
+                                                        <rect key="frame" x="390.5" y="0.0" width="114.5" height="66"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="키위쥬스 주문">
@@ -198,7 +198,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                        <rect key="frame" x="574.33333333333337" y="0.0" width="127.66666666666663" height="61.333333333333336"/>
+                                                        <rect key="frame" x="521" y="0.0" width="114" height="66"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="망고쥬스 주문">
@@ -260,7 +260,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DCG-dP-Fms" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="wpg-nM-F9y">
-                        <rect key="frame" x="0.0" y="0.0" width="852" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="667" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -277,30 +277,30 @@
             <objects>
                 <viewController storyboardIdentifier="StockViewController" id="Yu1-lM-nqp" customClass="StockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
-                        <rect key="frame" x="0.0" y="0.0" width="852" height="393"/>
+                        <rect key="frame" x="0.0" y="0.0" width="667" height="375"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="19" translatesAutoresizingMaskIntoConstraints="NO" id="7ng-3P-pVE">
-                                <rect key="frame" x="153" y="121.66666666666669" width="546" height="150"/>
+                                <rect key="frame" x="60.5" y="112.5" width="546" height="150.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="5Uf-et-jCD">
-                                        <rect key="frame" x="0.0" y="0.0" width="94" height="150"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="94" height="150.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                                <rect key="frame" x="9.6666666666666572" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="9.5" y="0.0" width="75" height="84"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                                <rect key="frame" x="40.333333333333343" y="87.666666666666671" width="13.333333333333336" height="26.333333333333329"/>
+                                                <rect key="frame" x="40.5" y="88" width="13.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                                <rect key="frame" x="0.0" y="118" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="118.5" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="onClickStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="VlQ-lE-MOS"/>
                                                 </connections>
@@ -308,23 +308,23 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="qNB-Vl-tZY">
-                                        <rect key="frame" x="113" y="0.0" width="94" height="150"/>
+                                        <rect key="frame" x="113" y="0.0" width="94" height="150.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                                <rect key="frame" x="9.6666666666666856" y="0.0" width="75" height="85.666666666666671"/>
+                                                <rect key="frame" x="9.5" y="0.0" width="75" height="86"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                                <rect key="frame" x="40.333333333333314" y="88.666666666666671" width="13.333333333333336" height="26.333333333333329"/>
+                                                <rect key="frame" x="40.5" y="89" width="13.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" tag="1" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                                <rect key="frame" x="0.0" y="118" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="118.5" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="onClickStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="Ot4-UD-a2v"/>
                                                 </connections>
@@ -332,23 +332,23 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="HAT-0N-I7e">
-                                        <rect key="frame" x="226" y="0.0" width="94" height="150"/>
+                                        <rect key="frame" x="226" y="0.0" width="94" height="150.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                                <rect key="frame" x="9.6666666666666856" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="9.5" y="0.0" width="75" height="84"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                                <rect key="frame" x="40.333333333333314" y="87.666666666666671" width="13.333333333333336" height="26.333333333333329"/>
+                                                <rect key="frame" x="40.5" y="88" width="13.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" tag="2" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                                <rect key="frame" x="0.0" y="118" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="118.5" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="onClickStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="5W3-5P-T4f"/>
                                                 </connections>
@@ -356,23 +356,23 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="ZTg-pi-Btv">
-                                        <rect key="frame" x="339" y="0.0" width="94" height="150"/>
+                                        <rect key="frame" x="339" y="0.0" width="94" height="150.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                                <rect key="frame" x="9.6666666666666856" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="9.5" y="0.0" width="75" height="84"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                                <rect key="frame" x="40.333333333333371" y="87.666666666666671" width="13.333333333333336" height="26.333333333333329"/>
+                                                <rect key="frame" x="40.5" y="88" width="13.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" tag="3" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                                <rect key="frame" x="0.0" y="118" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="118.5" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="onClickStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="XFG-RS-BoA"/>
                                                 </connections>
@@ -380,23 +380,23 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="w0t-Mb-sgY">
-                                        <rect key="frame" x="452" y="0.0" width="94" height="150"/>
+                                        <rect key="frame" x="452" y="0.0" width="94" height="150.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                                <rect key="frame" x="9.6666666666666288" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="9.5" y="0.0" width="75" height="84"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                                <rect key="frame" x="40.333333333333371" y="87.666666666666671" width="13.333333333333336" height="26.333333333333329"/>
+                                                <rect key="frame" x="40.5" y="88" width="13.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" tag="4" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                                <rect key="frame" x="0.0" y="118" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="118.5" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="onClickStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="Kfa-nS-QIA"/>
                                                 </connections>
@@ -405,15 +405,25 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MkX-9e-5A1">
-                                <rect key="frame" x="665" y="20" width="54" height="35"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="닫기"/>
-                                <connections>
-                                    <action selector="btnCloseStockView:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="eQb-34-sPU"/>
-                                </connections>
-                            </button>
+                            <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5xi-x8-gqj">
+                                <rect key="frame" x="0.0" y="0.0" width="667" height="44"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <items>
+                                    <navigationItem title="재고 추가" id="lfN-qf-YXz">
+                                        <barButtonItem key="rightBarButtonItem" style="plain" id="SHD-Uv-eJ3">
+                                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="MkX-9e-5A1">
+                                                <rect key="frame" x="593" y="4.5" width="54" height="35"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="닫기"/>
+                                                <connections>
+                                                    <action selector="btnCloseStockView:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="eQb-34-sPU"/>
+                                                </connections>
+                                            </button>
+                                        </barButtonItem>
+                                    </navigationItem>
+                                </items>
+                            </navigationBar>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina4_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -430,12 +430,12 @@
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <items>
                                     <navigationItem title="재고 추가" id="lfN-qf-YXz">
-                                        <barButtonItem key="rightBarButtonItem" style="plain" id="SHD-Uv-eJ3">
+                                        <barButtonItem key="rightBarButtonItem" style="done" id="SHD-Uv-eJ3">
                                             <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="MkX-9e-5A1">
-                                                <rect key="frame" x="494" y="4.5" width="54" height="35"/>
+                                                <rect key="frame" x="494" y="7.5" width="54" height="35"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                <state key="normal" title="Button"/>
-                                                <buttonConfiguration key="configuration" style="plain" title="닫기"/>
+                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                <state key="normal" title="닫기"/>
                                                 <connections>
                                                     <action selector="btnCloseStockView:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="eQb-34-sPU"/>
                                                 </connections>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina4_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -260,7 +260,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DCG-dP-Fms" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="wpg-nM-F9y">
-                        <rect key="frame" x="0.0" y="0.0" width="568" height="50"/>
+                        <rect key="frame" x="0.0" y="0.0" width="568" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -432,7 +432,7 @@
                                     <navigationItem title="재고 추가" id="lfN-qf-YXz">
                                         <barButtonItem key="rightBarButtonItem" style="plain" id="SHD-Uv-eJ3">
                                             <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="MkX-9e-5A1">
-                                                <rect key="frame" x="494" y="7.5" width="54" height="35"/>
+                                                <rect key="frame" x="494" y="4.5" width="54" height="35"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <state key="normal" title="Button"/>
                                                 <buttonConfiguration key="configuration" style="plain" title="닫기"/>
@@ -480,7 +480,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1418" y="120"/>
+            <point key="canvasLocation" x="1442" y="92"/>
         </scene>
     </scenes>
     <resources>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -13,7 +13,7 @@
         <!--맛있는 쥬스를 만들어 드려요!-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="StoreViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="StoreViewController" id="BYZ-38-t0r" customClass="StoreViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="568" height="320"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -432,7 +432,7 @@
                                     <navigationItem title="재고 추가" id="lfN-qf-YXz">
                                         <barButtonItem key="rightBarButtonItem" style="done" id="SHD-Uv-eJ3">
                                             <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="MkX-9e-5A1">
-                                                <rect key="frame" x="494" y="7.5" width="54" height="35"/>
+                                                <rect key="frame" x="494" y="4.5" width="54" height="35"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                 <state key="normal" title="닫기"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
-    <device id="retina4_7" orientation="landscape" appearance="light"/>
+    <device id="retina4_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
@@ -15,23 +15,23 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="StoreViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="667" height="375"/>
+                        <rect key="frame" x="0.0" y="0.0" width="568" height="320"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="16" y="64" width="635" height="131.5"/>
+                                <rect key="frame" x="16" y="64" width="536" height="112"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="114" height="131.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="94.5" height="112"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="114" height="97"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94.5" height="77.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="105" width="114" height="26.5"/>
+                                                <rect key="frame" x="0.0" y="85.5" width="94.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -40,16 +40,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="130" y="0.0" width="114.5" height="131.5"/>
+                                        <rect key="frame" x="110.5" y="0.0" width="94.5" height="112"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="114.5" height="97"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94.5" height="77.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="105" width="114.5" height="26.5"/>
+                                                <rect key="frame" x="0.0" y="85.5" width="94.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -58,16 +58,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="260.5" y="0.0" width="114" height="131.5"/>
+                                        <rect key="frame" x="221" y="0.0" width="94" height="112"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="114" height="97"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="77.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="105" width="114" height="26.5"/>
+                                                <rect key="frame" x="0.0" y="85.5" width="94" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -76,16 +76,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="390.5" y="0.0" width="114.5" height="131.5"/>
+                                        <rect key="frame" x="331" y="0.0" width="94.5" height="112"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="114.5" height="97"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94.5" height="77.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="105" width="114.5" height="26.5"/>
+                                                <rect key="frame" x="0.0" y="85.5" width="94.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -94,16 +94,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="521" y="0.0" width="114" height="131.5"/>
+                                        <rect key="frame" x="441.5" y="0.0" width="94.5" height="112"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="114" height="97"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94.5" height="77.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="105" width="114" height="26.5"/>
+                                                <rect key="frame" x="0.0" y="85.5" width="94.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -114,13 +114,13 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="16" y="215.5" width="635" height="139.5"/>
+                                <rect key="frame" x="16" y="196" width="536" height="104"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="635" height="65.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="536" height="48"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="244.5" height="65.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="205" height="48"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="딸바쥬스 주문">
@@ -131,11 +131,11 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
-                                                <rect key="frame" x="260.5" y="0.0" width="114" height="65.5"/>
+                                                <rect key="frame" x="221" y="0.0" width="94" height="48"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
                                             <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="390.5" y="0.0" width="244.5" height="65.5"/>
+                                                <rect key="frame" x="331" y="0.0" width="205" height="48"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
@@ -148,13 +148,13 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="73.5" width="635" height="66"/>
+                                        <rect key="frame" x="0.0" y="56" width="536" height="48"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="635" height="66"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="536" height="48"/>
                                                 <subviews>
                                                     <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="114" height="66"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="94.5" height="48"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="딸기쥬스 주문">
@@ -165,7 +165,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="130" y="0.0" width="114.5" height="66"/>
+                                                        <rect key="frame" x="110.5" y="0.0" width="94.5" height="48"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="바나나쥬스 주문">
@@ -176,7 +176,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
-                                                        <rect key="frame" x="260.5" y="0.0" width="114" height="66"/>
+                                                        <rect key="frame" x="221" y="0.0" width="94" height="48"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="파인애플쥬스 주문">
@@ -187,7 +187,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="390.5" y="0.0" width="114.5" height="66"/>
+                                                        <rect key="frame" x="331" y="0.0" width="94.5" height="48"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="키위쥬스 주문">
@@ -198,7 +198,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                        <rect key="frame" x="521" y="0.0" width="114" height="66"/>
+                                                        <rect key="frame" x="441.5" y="0.0" width="94.5" height="48"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="망고쥬스 주문">
@@ -260,7 +260,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DCG-dP-Fms" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="wpg-nM-F9y">
-                        <rect key="frame" x="0.0" y="0.0" width="667" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="568" height="50"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -277,23 +277,23 @@
             <objects>
                 <viewController storyboardIdentifier="StockViewController" id="Yu1-lM-nqp" customClass="StockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
-                        <rect key="frame" x="0.0" y="0.0" width="667" height="375"/>
+                        <rect key="frame" x="0.0" y="0.0" width="568" height="320"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="19" translatesAutoresizingMaskIntoConstraints="NO" id="7ng-3P-pVE">
-                                <rect key="frame" x="60.5" y="112.5" width="546" height="150.5"/>
+                                <rect key="frame" x="11" y="85" width="546" height="150.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="5Uf-et-jCD">
                                         <rect key="frame" x="0.0" y="0.0" width="94" height="150.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                                <rect key="frame" x="9.5" y="0.0" width="75" height="84"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="84"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                                <rect key="frame" x="40.5" y="88" width="13.5" height="26.5"/>
+                                                <rect key="frame" x="0.0" y="88" width="94" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -306,18 +306,22 @@
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="0yV-kn-zaT" firstAttribute="width" secondItem="dCK-AJ-zGU" secondAttribute="width" id="NaW-nV-Egt"/>
+                                            <constraint firstItem="ZQk-f4-zrz" firstAttribute="width" secondItem="dCK-AJ-zGU" secondAttribute="width" id="aR3-ZG-3x8"/>
+                                        </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="qNB-Vl-tZY">
                                         <rect key="frame" x="113" y="0.0" width="94" height="150.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                                <rect key="frame" x="9.5" y="0.0" width="75" height="86"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="86"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                                <rect key="frame" x="40.5" y="89" width="13.5" height="26.5"/>
+                                                <rect key="frame" x="0.0" y="89" width="94" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -330,18 +334,22 @@
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="O5s-2N-3iP" firstAttribute="width" secondItem="y33-ND-gz2" secondAttribute="width" id="FK7-0n-Lky"/>
+                                            <constraint firstItem="gKu-86-RhI" firstAttribute="width" secondItem="y33-ND-gz2" secondAttribute="width" id="bqX-xM-C1H"/>
+                                        </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="HAT-0N-I7e">
                                         <rect key="frame" x="226" y="0.0" width="94" height="150.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                                <rect key="frame" x="9.5" y="0.0" width="75" height="84"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="84"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                                <rect key="frame" x="40.5" y="88" width="13.5" height="26.5"/>
+                                                <rect key="frame" x="0.0" y="88" width="94" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -354,18 +362,22 @@
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="Rcr-xr-eqz" firstAttribute="width" secondItem="rac-Ji-vZK" secondAttribute="width" id="CUW-KQ-zs6"/>
+                                            <constraint firstItem="MpT-VW-hCb" firstAttribute="width" secondItem="rac-Ji-vZK" secondAttribute="width" id="yeG-H5-c72"/>
+                                        </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="ZTg-pi-Btv">
                                         <rect key="frame" x="339" y="0.0" width="94" height="150.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                                <rect key="frame" x="9.5" y="0.0" width="75" height="84"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="84"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                                <rect key="frame" x="40.5" y="88" width="13.5" height="26.5"/>
+                                                <rect key="frame" x="0.0" y="88" width="94" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -378,18 +390,22 @@
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="ZDv-1m-HBY" firstAttribute="width" secondItem="EHe-D1-1xN" secondAttribute="width" id="rq6-OR-iqT"/>
+                                            <constraint firstItem="klA-59-Nu4" firstAttribute="width" secondItem="EHe-D1-1xN" secondAttribute="width" id="tJk-wc-GaD"/>
+                                        </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="w0t-Mb-sgY">
                                         <rect key="frame" x="452" y="0.0" width="94" height="150.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                                <rect key="frame" x="9.5" y="0.0" width="75" height="84"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="84"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                                <rect key="frame" x="40.5" y="88" width="13.5" height="26.5"/>
+                                                <rect key="frame" x="0.0" y="88" width="94" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -402,17 +418,21 @@
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="xbn-6P-grO" firstAttribute="width" secondItem="w1F-9o-qJR" secondAttribute="width" id="81k-3C-KxG"/>
+                                            <constraint firstItem="YJI-ER-LJR" firstAttribute="width" secondItem="w1F-9o-qJR" secondAttribute="width" id="m36-1t-MpQ"/>
+                                        </constraints>
                                     </stackView>
                                 </subviews>
                             </stackView>
                             <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5xi-x8-gqj">
-                                <rect key="frame" x="0.0" y="0.0" width="667" height="44"/>
+                                <rect key="frame" x="0.0" y="0.0" width="568" height="44"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <items>
                                     <navigationItem title="재고 추가" id="lfN-qf-YXz">
                                         <barButtonItem key="rightBarButtonItem" style="plain" id="SHD-Uv-eJ3">
                                             <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="MkX-9e-5A1">
-                                                <rect key="frame" x="593" y="4.5" width="54" height="35"/>
+                                                <rect key="frame" x="494" y="7.5" width="54" height="35"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <state key="normal" title="Button"/>
                                                 <buttonConfiguration key="configuration" style="plain" title="닫기"/>
@@ -431,8 +451,8 @@
                             <constraint firstItem="7ng-3P-pVE" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="gcO-Xb-kNs" secondAttribute="leading" constant="10" id="71N-Sd-fcA"/>
                             <constraint firstItem="7ng-3P-pVE" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="Cjw-18-52x"/>
                             <constraint firstItem="gcO-Xb-kNs" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="7ng-3P-pVE" secondAttribute="trailing" constant="10" id="MQF-ye-j6i"/>
-                            <constraint firstItem="gcO-Xb-kNs" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="7ng-3P-pVE" secondAttribute="trailing" constant="150" id="bAJ-bA-Sjn"/>
-                            <constraint firstItem="7ng-3P-pVE" firstAttribute="leading" relation="lessThanOrEqual" secondItem="gcO-Xb-kNs" secondAttribute="leading" constant="150" id="kMd-Y0-C6S"/>
+                            <constraint firstItem="gcO-Xb-kNs" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="7ng-3P-pVE" secondAttribute="trailing" constant="60" id="bAJ-bA-Sjn"/>
+                            <constraint firstItem="7ng-3P-pVE" firstAttribute="leading" relation="lessThanOrEqual" secondItem="gcO-Xb-kNs" secondAttribute="leading" constant="60" id="kMd-Y0-C6S"/>
                             <constraint firstItem="7ng-3P-pVE" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="ukq-G0-PpD"/>
                         </constraints>
                     </view>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
-# ios-juice-maker
-쥬스메이커 프로젝트 저장소입니다. 
+# 쥬스 메이커 앱
+
+사용자가 주문 화면을 통해 과일 쥬스를 만들어 내는 앱 입니다.
+
+## 팀원
+
+| <img src="https://github.com/Gnoam-R/ARAD_Public/assets/67363759/44a01b47-c80b-49ca-b30b-19a9061a52a0" width=120> | <img src="https://avatars.githubusercontent.com/u/67363759?v=4" width=120> |
+| --- | --- |
+| 폴<br/>https://github.com/earths-voluble | 노움<br/>https://github.com/rohhyungwoo |
+
+## STEP1
+
+- 쥬스 주문 로직 구현
+    - Dictionary 입력된 쥬스 네이밍을 판단하여 필요한 과일의 수량을 반환한다.
+    - 문자열 파싱으로 쥬스에 연관된 과일 정보를 구분, 과일 객체의 속성에 접근한다.
+- ErrorHandling
+    - 정상적인 입력인가, 과일 수량은 충분한가에 대한 에러 처리를 진행
+
+## STEP2
+
+- View와 Model 연결
+    - View의 버튼과 주문 로직을 연결
+    - 과일 수량 View와 과일 저장소를 연결
+- 화면 이동
+    - Navigation 화면 이동
+    - Modal 화면 이동
+
+## STEP3
+
+- 다른 View간의 데이터 연결
+    - 싱글톤 패턴을 사용하여 하나의 인스턴스만을 생성
+- 화면 구성
+    - AutoLayout으로 다양한 디바이스에 대한 화면 구성
+    - Custom View 생성
+ 
+## UML
+![JuiceMaker](https://github.com/earths-voluble/ios-juice-maker/assets/103843007/80b61952-f281-499d-b020-6248417d27e2)
+


### PR DESCRIPTION
## 인사말
@yim2627 @Gnoam-R @earths-voluble

안녕하세요 지성!

Juice Maker Step3 리뷰 요청 드립니다.

Step3에서는 AutoLayout을 사용해서 과일 저장소 뷰를 조절 했습니다. 그리고 싱글톤 패턴을 사용하여 서로 다른 클래스에 FruitStore 객체의 의존성을 공유하는 방식을 채택하여 UI에 값을 적용하는 코드를 구현하게 되었습니다.

## 구현 내용 설명

- `StockViewController` AutoLayout 적용
<img width="1000" alt="Screenshot 2023-12-22 at 10 25 24" src="https://github.com/tasty-code/ios-juice-maker/assets/103843007/a9521b71-e45e-4fba-9569-f36728baffc3">

    
- 네비게이션 바에 제목 및 닫기 버튼 추가
    - `StockVIewController` 에서 닫기 버튼을 클릭시 `dismiss` 를 실행, 모달을 닫고 메인 뷰로 화면이 전환 됩니다.
- Stepper & 재고 수량 Label 반영
    - Stepper의 심벌에 초기 값을 저장하고 버튼이 눌릴 때 변경되는 값을 `Label`과 `FruitStore` 에 저장합니다.
    - Stepper의 최소값을 설정하여 음수로 값이 내려가는 현상을 방지했습니다.
- Main과 Modal화면의 과일 수량 일체화
    - `StockViewController`의 닫기 버튼을 클릭 시 `StoreViewController`의 재고 수량 화면에 변경된 과일 값을 입력합니다.
    - 위 요구사항을 동작시키기 위해서 `FruitStore` 객체를 싱글턴으로 생성, 쥬스 주문 또는 `StockVIewController`의 버튼 클릭으로 변경되는 과일의 수량값을 즉시 저장하고 화면에 적용하는 로직을 구현했습니다.

### UML
![JuiceMaker](https://github.com/tasty-code/ios-juice-maker/assets/103843007/ef29a75b-7845-45d5-b68e-8e9e9f457609)
## 쥬스 메이커 동작 화면

<br>
<h1 align="center">
<br>

![292069471-a1dc30b8-655d-4510-8b23-ad9a3ddd2468](https://github.com/tasty-code/ios-juice-maker/assets/103843007/af11e312-1a86-4e72-b78b-e5a4324122fa)

<br>

</h1>
<br>

## 궁금한점

서로 다른 ViewController에서 동일한 클래스에 있는 과일 수량 값을 가져와 화면에 뿌려주는 방법에 대해 다양한 방법들이 존재하겠지만 저희는 싱글톤 패턴을 적용했습니다. 이유는 현재는 2개의 클래스에서 `FruitStore` 의  의존성을 받고 있지만 더 많은 클래스에서 사용 되는 경우 객체를 하나만 생성해도 여러 곳에서 가져와 사용할 수 있게 하는 점이 장점이라 생각했어요. 하지만 사용하게 되면서 순환 참조와 같은 문제점과 대규모 프로젝트에서 단위 테스트에 대한 어려움이 있을것이다 라는 이야기를 들어서 더 좋은 방법을 찾고자 합니다. 지성이라면 이 프로젝트에서 어떤 방법을 사용하실 건가요?