### PR TITLE
쥬스메이커 [STEP 3] Nnn, Sam

### DIFF
--- a/JuiceMaker/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1D541BA42B3131B100581F8E /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D541BA32B3131B100581F8E /* CustomButton.swift */; };
 		1D97DE9F2B205CE600AB00FC /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D97DE9D2B205CE500AB00FC /* Fruit.swift */; };
 		1D97DEA02B205CE600AB00FC /* ErrorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D97DE9E2B205CE600AB00FC /* ErrorType.swift */; };
 		1DA88AB22B21A788003DB903 /* SecondViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA88AB12B21A788003DB903 /* SecondViewController.swift */; };
@@ -22,6 +23,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1D541BA32B3131B100581F8E /* CustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
 		1D97DE9D2B205CE500AB00FC /* Fruit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
 		1D97DE9E2B205CE600AB00FC /* ErrorType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorType.swift; sourceTree = "<group>"; };
 		1DA88AB12B21A788003DB903 /* SecondViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondViewController.swift; sourceTree = "<group>"; };
@@ -56,6 +58,7 @@
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
 				C73DAF3A255D0CDD00020D38 /* ViewController.swift */,
 				1DA88AB12B21A788003DB903 /* SecondViewController.swift */,
+				1D541BA32B3131B100581F8E /* CustomButton.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -183,6 +186,7 @@
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
 				1D97DEA02B205CE600AB00FC /* ErrorType.swift in Sources */,
 				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
+				1D541BA42B3131B100581F8E /* CustomButton.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
 				1D97DE9F2B205CE600AB00FC /* Fruit.swift in Sources */,

--- a/JuiceMaker/JuiceMaker/JuiceMaker/Controller/CustomButton.swift
+++ b/JuiceMaker/JuiceMaker/JuiceMaker/Controller/CustomButton.swift
@@ -1,0 +1,22 @@
+//
+//  CustomButton.swift
+//  JuiceMaker
+//
+//  Created by 박찬호 on 12/19/23.
+//
+
+import UIKit
+
+class CustomButton: UIButton {
+    let padding: CGFloat = 10
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        self.titleLabel?.adjustsFontSizeToFitWidth = true
+        self.titleLabel?.minimumScaleFactor = 0.5
+
+        self.contentEdgeInsets = UIEdgeInsets(top: 0, left: padding, bottom: 0, right: padding)
+    }
+}
+

--- a/JuiceMaker/JuiceMaker/JuiceMaker/Controller/SecondViewController.swift
+++ b/JuiceMaker/JuiceMaker/JuiceMaker/Controller/SecondViewController.swift
@@ -34,9 +34,74 @@ class SecondViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationItem.setHidesBackButton(true, animated: true)
+        setupStockDisplay()
     }
-
-
+    
+    func setupStockDisplay() {
+        fruitStockDisplay(fruit: .strawberry, label: strawberryStockLabel, stepper: strawberryStockStepper)
+        fruitStockDisplay(fruit: .banana, label: bananaStockLabel, stepper: bananaStockStepper)
+        fruitStockDisplay(fruit: .kiwi, label: kiwiStockLabel, stepper: kiwiStockStepper)
+        fruitStockDisplay(fruit: .mango, label: mangoStockLabel, stepper: mangoStockStepper)
+        fruitStockDisplay(fruit: .pineapple, label: pineappleStockLabel, stepper: pineappleStockStepper)
+    }
+    
+    func fruitStockDisplay(fruit: Fruit, label: UILabel, stepper: UIStepper) {
+        guard let quantity = juiceMaker?.fruitStore.getQuantity(of: fruit) else {
+            label.text = "N/A"
+            stepper.isEnabled = false
+            return
+        }
+        label.text = "\(quantity)"
+        stepper.value = Double(quantity)
+        stepper.minimumValue = 0
+        stepper.maximumValue = 100
+    }
+    
+    @IBAction func strawberryStepperChanged(_ sender: UIStepper) {
+        updateFruitStock(fruit: .strawberry, newValue: Int(sender.value))
+    }
+    @IBAction func bananaStepperChanged(_ sender: UIStepper) {
+        updateFruitStock(fruit: .banana, newValue: Int(sender.value))
+    }
+    @IBAction func pineappleStepperChanged(_ sender: UIStepper) {
+        updateFruitStock(fruit: .pineapple, newValue: Int(sender.value))
+    }
+    @IBAction func kiwiStepperChanged(_ sender: UIStepper) {
+        updateFruitStock(fruit: .kiwi, newValue: Int(sender.value))
+    }
+    @IBAction func mangoStepperChanged(_ sender: UIStepper) {
+        updateFruitStock(fruit: .mango, newValue: Int(sender.value))
+    }
+    
+    
+    
+    
+    func updateFruitStock(fruit: Fruit, newValue: Int) {
+        juiceMaker?.fruitStore.setQuantity(of: fruit, to: newValue)
+        updateLabel(for: fruit, with: newValue)
+    }
+    
+    func updateLabel(for fruit: Fruit, with quantity: Int ) {
+        switch fruit {
+        case .strawberry:
+            strawberryStockLabel.text = "\(quantity)"
+        case .banana:
+            bananaStockLabel.text = "\(quantity)"
+        case .kiwi:
+            kiwiStockLabel.text = "\(quantity)"
+        case .mango:
+            mangoStockLabel.text = "\(quantity)"
+        case .pineapple:
+            pineappleStockLabel.text = "\(quantity)"
+        default:
+            break
+        }
+    }
+    
+    
+    @IBAction func completeButton(_ sender: UIBarButtonItem) {
+        delegate?.didUpdateFruitStock()
+        dismiss(animated: true, completion: nil)
+    }
+    
 }
-

--- a/JuiceMaker/JuiceMaker/JuiceMaker/Controller/SecondViewController.swift
+++ b/JuiceMaker/JuiceMaker/JuiceMaker/Controller/SecondViewController.swift
@@ -14,7 +14,23 @@ protocol SecondViewControllerDelegate: AnyObject {
 
 class SecondViewController: UIViewController {
     
-    var data: [String] = []
+    @IBOutlet weak var strawberryStockLabel: UILabel!
+    @IBOutlet weak var strawberryStockStepper: UIStepper!
+    
+    @IBOutlet weak var bananaStockLabel: UILabel!
+    @IBOutlet weak var bananaStockStepper: UIStepper!
+    
+    @IBOutlet weak var pineappleStockLabel: UILabel!
+    @IBOutlet weak var pineappleStockStepper: UIStepper!
+    
+    @IBOutlet weak var kiwiStockLabel: UILabel!
+    @IBOutlet weak var kiwiStockStepper: UIStepper!
+    
+    @IBOutlet weak var mangoStockLabel: UILabel!
+    @IBOutlet weak var mangoStockStepper: UIStepper!
+    
+    weak var delegate: SecondViewControllerDelegate?
+    var juiceMaker: JuiceMaker?
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/JuiceMaker/JuiceMaker/JuiceMaker/Controller/SecondViewController.swift
+++ b/JuiceMaker/JuiceMaker/JuiceMaker/Controller/SecondViewController.swift
@@ -8,6 +8,10 @@
 
 import UIKit
 
+protocol SecondViewControllerDelegate: AnyObject {
+    func didUpdateFruitStock()
+}
+
 class SecondViewController: UIViewController {
     
     var data: [String] = []

--- a/JuiceMaker/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -56,6 +56,7 @@ class ViewController: UIViewController {
             updateStockLabel()
             present(successAlert, animated: true)
         } catch ErrorType.insufficientFruits {
+            
             let stockAlert = UIAlertController(title: "재고 부족", message: "\(juice.name) 재료가 모자라요. 재고를 수정할까요?", preferredStyle: .alert)
             
             let actionYes = UIAlertAction(title: "예", style: .default, handler: {_ in
@@ -64,20 +65,19 @@ class ViewController: UIViewController {
             
             let actionNo = UIAlertAction(title: "아니요", style: .cancel)
             
-            actionYes.setValue(UIColor.red, forKey: "titleTextColor")
+            actionNo.setValue(UIColor.red, forKey: "titleTextColor")
             
-            stockAlert.addAction(actionYes)
             stockAlert.addAction(actionNo)
+            stockAlert.addAction(actionYes)
             
             present(stockAlert, animated: true)
         } catch {
             print("Unknown error")
         }
     }
+    
     @IBAction func stockUpdateAction(_ sender: UIBarButtonItem) {
-        guard let vc2 = self.storyboard?.instantiateViewController(withIdentifier: "secondVC") as? SecondViewController else { return }
-        self.navigationController?.pushViewController(vc2, animated: false)
-//        self.navigationItem.leftBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        presentSecondViewController()
     }
     
     func updateStockLabel() {

--- a/JuiceMaker/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -12,6 +12,10 @@ class FruitStore {
     init() {
         inventory = [.banana: 10, .kiwi: 10, .mango: 10, .pineapple: 10, .strawberry: 10]
     }
+    
+    func setQuantity(of fruit: Fruit, to newQuantity: Int) {
+        inventory[fruit] = newQuantity
+    }
 
     func updateInventory(fruit: Fruit, quantity: Int) {
         guard let currentQuantity = inventory[fruit] else { return }

--- a/JuiceMaker/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
-    <device id="retina6_0" orientation="landscape" appearance="light"/>
+    <device id="retina6_7" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
@@ -14,20 +14,20 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
+                        <rect key="frame" x="0.0" y="0.0" width="926" height="428"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="63" y="63.999999999999986" width="718" height="136.66666666666663"/>
+                                <rect key="frame" x="63" y="63.999999999999986" width="800" height="149.66666666666663"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="136.66666666666666"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="147.33333333333334" height="149.66666666666666"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" image="miniensStoryboard" translatesAutoresizingMaskIntoConstraints="NO" id="Poo-qJ-7eN">
-                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="147.33333333333334" height="115.33333333333333"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="123.33333333333333" width="147.33333333333334" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -36,13 +36,13 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="136.66666666666666"/>
+                                        <rect key="frame" x="163.33333333333334" y="0.0" width="147.00000000000003" height="149.66666666666666"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" image="miniBanana 1" translatesAutoresizingMaskIntoConstraints="NO" id="mAU-CC-cJI">
-                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="147" height="115.33333333333333"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="123.33333333333333" width="147" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -51,13 +51,13 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="136.66666666666666"/>
+                                        <rect key="frame" x="326.33333333333331" y="0.0" width="147.33333333333331" height="149.66666666666666"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" image="miniensPineapple" translatesAutoresizingMaskIntoConstraints="NO" id="JFt-Ub-eyI">
-                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="147.33333333333334" height="115.33333333333333"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="123.33333333333333" width="147.33333333333334" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -66,13 +66,13 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="136.66666666666666"/>
+                                        <rect key="frame" x="489.66666666666663" y="0.0" width="147" height="149.66666666666666"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" image="miniensKiwi" translatesAutoresizingMaskIntoConstraints="NO" id="aYZ-wg-kAl">
-                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="147" height="115.33333333333333"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" tag="3" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="123.33333333333333" width="147" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -81,13 +81,13 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="136.66666666666666"/>
+                                        <rect key="frame" x="652.66666666666663" y="0.0" width="147.33333333333337" height="149.66666666666666"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" image="miniensMango" translatesAutoresizingMaskIntoConstraints="NO" id="yAL-1d-Z2r">
-                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="147.33333333333334" height="115.33333333333333"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" tag="4" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="123.33333333333333" width="147.33333333333334" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -98,13 +98,13 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="63" y="220.66666666666663" width="718" height="128.33333333333337"/>
+                                <rect key="frame" x="63" y="233.66666666666663" width="800" height="153.33333333333337"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq" colorLabel="IBBuiltInLabel-Yellow">
-                                        <rect key="frame" x="0.0" y="0.0" width="718" height="60"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="800" height="72.666666666666671"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="277.66666666666669" height="60"/>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl" customClass="CustomButton" customModule="JuiceMaker" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="0.0" width="310.33333333333331" height="72.666666666666671"/>
                                                 <color key="backgroundColor" red="0.98563152549999999" green="0.71392947439999999" blue="0.75635266300000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -122,7 +122,7 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
-                                                <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="60"/>
+                                                <rect key="frame" x="326.33333333333331" y="0.0" width="147.33333333333331" height="72.666666666666671"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" fixedFrame="YES" image="Bab" translatesAutoresizingMaskIntoConstraints="NO" id="BqO-YL-vEH">
                                                         <rect key="frame" x="-3" y="0.0" width="134" height="60"/>
@@ -131,8 +131,8 @@
                                                 </subviews>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
-                                            <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="440.33333333333326" y="0.0" width="277.66666666666674" height="60"/>
+                                            <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii" customClass="CustomButton" customModule="JuiceMaker" customModuleProvider="target">
+                                                <rect key="frame" x="489.66666666666663" y="0.0" width="310.33333333333337" height="72.666666666666671"/>
                                                 <color key="backgroundColor" red="0.98673862219999997" green="0.79990023369999996" blue="0.398240447" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                 <state key="normal" title="망키쥬스 주문">
@@ -157,13 +157,13 @@
                                         </userDefinedRuntimeAttributes>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="68.000000000000028" width="718" height="60.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="80.666666666666657" width="800" height="72.666666666666657"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="718" height="60.333333333333336"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="800" height="72.666666666666671"/>
                                                 <subviews>
-                                                    <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="60.333333333333336"/>
+                                                    <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM" customClass="CustomButton" customModule="JuiceMaker" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="0.0" width="147.33333333333334" height="72.666666666666671"/>
                                                         <color key="backgroundColor" red="0.97534781690000005" green="0.38749009369999998" blue="0.27738958600000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                         <state key="normal" title="딸기쥬스 주문">
@@ -179,8 +179,8 @@
                                                             <action selector="orderJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Yhn-Vj-mL1"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="60.333333333333336"/>
+                                                    <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY" customClass="CustomButton" customModule="JuiceMaker" customModuleProvider="target">
+                                                        <rect key="frame" x="163.33333333333334" y="0.0" width="147.00000000000003" height="72.666666666666671"/>
                                                         <color key="backgroundColor" red="0.98959547280000004" green="0.88066589829999997" blue="0.2084983587" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                         <state key="normal" title="바나나쥬스 주문">
@@ -196,8 +196,8 @@
                                                             <action selector="orderJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="x2A-eU-Aip"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
-                                                        <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="60.333333333333336"/>
+                                                    <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA" customClass="CustomButton" customModule="JuiceMaker" customModuleProvider="target">
+                                                        <rect key="frame" x="326.33333333333331" y="0.0" width="147.33333333333331" height="72.666666666666671"/>
                                                         <color key="backgroundColor" red="0.80000000000000004" green="0.59999999999999998" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                         <state key="normal" title="파인애플쥬스 주문">
@@ -213,8 +213,8 @@
                                                             <action selector="orderJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="wmX-Dy-k9O"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="60.333333333333336"/>
+                                                    <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw" customClass="CustomButton" customModule="JuiceMaker" customModuleProvider="target">
+                                                        <rect key="frame" x="489.66666666666663" y="0.0" width="147" height="72.666666666666671"/>
                                                         <color key="backgroundColor" red="0.60556691880000002" green="0.80521363020000003" blue="0.19464898110000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                         <state key="normal" title="키위쥬스 주문">
@@ -230,8 +230,8 @@
                                                             <action selector="orderJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="lun-tA-S33"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                        <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="60.333333333333336"/>
+                                                    <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm" customClass="CustomButton" customModule="JuiceMaker" customModuleProvider="target">
+                                                        <rect key="frame" x="652.66666666666663" y="0.0" width="147.33333333333337" height="72.666666666666671"/>
                                                         <color key="backgroundColor" red="0.98081058259999998" green="0.64526903629999999" blue="0.0040307822639999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                         <state key="normal" title="망고쥬스 주문">
@@ -276,7 +276,7 @@
                     </view>
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
-                            <color key="tintColor" red="0.78823530669999997" green="0.28627452250000002" blue="0.20000001789999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                            <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <connections>
                                 <action selector="stockUpdateAction:" destination="BYZ-38-t0r" id="s7q-CS-9vd"/>
                             </connections>
@@ -289,7 +289,6 @@
                         <outletCollection property="FruitLabel" destination="ccQ-Dk-PuY" collectionClass="NSMutableArray" id="3mk-ab-ol2"/>
                         <outletCollection property="FruitLabel" destination="FZq-de-TJG" collectionClass="NSMutableArray" id="PVp-9H-ZK3"/>
                         <outletCollection property="FruitLabel" destination="3Ce-SU-JeH" collectionClass="NSMutableArray" id="y65-1Y-Cgg"/>
-                        <segue destination="Yu1-lM-nqp" kind="show" identifier="secondVC" id="z67-rM-F6w"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -302,7 +301,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DCG-dP-Fms" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="wpg-nM-F9y">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="926" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -314,127 +313,170 @@
             </objects>
             <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
         </scene>
-        <!--Second View Controller-->
+        <!--재고관리-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
                 <viewController storyboardIdentifier="secondVC" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Yu1-lM-nqp" customClass="SecondViewController" customModule="JuiceMaker" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
+                        <rect key="frame" x="0.0" y="0.0" width="926" height="428"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="FoF-R4-2Xz">
-                                <rect key="frame" x="107" y="117" width="630" height="156"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="31" translatesAutoresizingMaskIntoConstraints="NO" id="maT-a4-Oji">
+                                <rect key="frame" x="166" y="132" width="594" height="164"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="f4m-tX-xwZ">
-                                        <rect key="frame" x="0.0" y="0.0" width="94" height="156"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="RE3-Do-Drj">
+                                        <rect key="frame" x="0.0" y="0.0" width="94" height="164"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                                <rect key="frame" x="9.6666666666666714" y="0.0" width="75" height="85.666666666666671"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                                <rect key="frame" x="40.333333333333343" y="91.666666666666657" width="13.333333333333336" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="94.666666666666657" width="94" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                                <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="753" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
+                                                <rect key="frame" x="0.0" y="132" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="strawberryStepperChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="Sv1-vY-YZH"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="ZQk-f4-zrz" firstAttribute="width" secondItem="dCK-AJ-zGU" secondAttribute="width" id="57P-md-OjC"/>
+                                            <constraint firstItem="dCK-AJ-zGU" firstAttribute="centerX" secondItem="RE3-Do-Drj" secondAttribute="centerX" id="FUn-kB-h77"/>
+                                            <constraint firstItem="ZQk-f4-zrz" firstAttribute="centerX" secondItem="RE3-Do-Drj" secondAttribute="centerX" id="NML-hu-KTV"/>
+                                            <constraint firstItem="0yV-kn-zaT" firstAttribute="centerX" secondItem="RE3-Do-Drj" secondAttribute="centerX" id="i87-mc-zfe"/>
+                                            <constraint firstItem="0yV-kn-zaT" firstAttribute="width" secondItem="dCK-AJ-zGU" secondAttribute="width" id="rQR-I1-qIj"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="Vp2-bM-yME">
-                                        <rect key="frame" x="134" y="0.0" width="94" height="156"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="CJl-XH-Vfr">
+                                        <rect key="frame" x="125" y="0.0" width="94" height="164"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                                <rect key="frame" x="9.6666666666666572" y="0.0" width="75" height="91.666666666666671"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                                <rect key="frame" x="40.333333333333314" y="94.666666666666657" width="13.333333333333336" height="26.333333333333329"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="749" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
+                                                <rect key="frame" x="0.0" y="94.666666666666657" width="94" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                                <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="751" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
+                                                <rect key="frame" x="0.0" y="132" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="bananaStepperChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="W7O-is-yz9"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="O5s-2N-3iP" firstAttribute="width" secondItem="y33-ND-gz2" secondAttribute="width" id="1tq-1R-qQX"/>
+                                            <constraint firstItem="y33-ND-gz2" firstAttribute="centerX" secondItem="CJl-XH-Vfr" secondAttribute="centerX" id="2E6-yr-lvS"/>
+                                            <constraint firstItem="gKu-86-RhI" firstAttribute="width" secondItem="y33-ND-gz2" secondAttribute="width" id="IfC-bX-umW"/>
+                                            <constraint firstItem="O5s-2N-3iP" firstAttribute="centerX" secondItem="CJl-XH-Vfr" secondAttribute="centerX" id="bhM-4G-shu"/>
+                                            <constraint firstItem="gKu-86-RhI" firstAttribute="centerX" secondItem="CJl-XH-Vfr" secondAttribute="centerX" id="eZ6-O5-rne"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="aCf-N3-SSt">
-                                        <rect key="frame" x="268" y="0.0" width="94" height="156"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="CCk-Lt-BZL">
+                                        <rect key="frame" x="250" y="0.0" width="94" height="164"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                                <rect key="frame" x="9.6666666666666856" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                                <rect key="frame" x="40.333333333333314" y="90.666666666666657" width="13.333333333333336" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="94.666666666666657" width="94" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                                <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="752" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
+                                                <rect key="frame" x="0.0" y="132" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="pineappleStepperChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="C1j-xT-HsF"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="Rcr-xr-eqz" firstAttribute="width" secondItem="rac-Ji-vZK" secondAttribute="width" id="PLi-xv-Dbw"/>
+                                            <constraint firstItem="MpT-VW-hCb" firstAttribute="centerX" secondItem="CCk-Lt-BZL" secondAttribute="centerX" id="cZ5-nL-og7"/>
+                                            <constraint firstItem="MpT-VW-hCb" firstAttribute="width" secondItem="rac-Ji-vZK" secondAttribute="width" id="tXw-5B-BM6"/>
+                                            <constraint firstItem="rac-Ji-vZK" firstAttribute="centerX" secondItem="CCk-Lt-BZL" secondAttribute="centerX" id="tj3-51-zg6"/>
+                                            <constraint firstItem="Rcr-xr-eqz" firstAttribute="centerX" secondItem="CCk-Lt-BZL" secondAttribute="centerX" id="ybl-tW-cLq"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="8yp-4Z-j6a">
-                                        <rect key="frame" x="402" y="0.0" width="94" height="156"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="ea4-BJ-QpY">
+                                        <rect key="frame" x="375" y="0.0" width="94" height="164"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                                <rect key="frame" x="9.6666666666666288" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                                <rect key="frame" x="40.333333333333371" y="90.666666666666657" width="13.333333333333336" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="94.666666666666657" width="94" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                                <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="751" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
+                                                <rect key="frame" x="0.0" y="132" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="kiwiStepperChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="Mae-xu-fVK"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="100" id="AYU-sY-j2z"/>
-                                            <constraint firstAttribute="height" constant="200" id="Vyn-GK-plq"/>
+                                            <constraint firstItem="ZDv-1m-HBY" firstAttribute="width" secondItem="EHe-D1-1xN" secondAttribute="width" id="Ebt-5S-3rn"/>
+                                            <constraint firstItem="EHe-D1-1xN" firstAttribute="centerX" secondItem="ea4-BJ-QpY" secondAttribute="centerX" id="K8i-uO-ddz"/>
+                                            <constraint firstItem="klA-59-Nu4" firstAttribute="centerX" secondItem="ea4-BJ-QpY" secondAttribute="centerX" id="Zko-qB-UW9"/>
+                                            <constraint firstItem="klA-59-Nu4" firstAttribute="width" secondItem="EHe-D1-1xN" secondAttribute="width" id="b7F-dA-nY0"/>
+                                            <constraint firstItem="ZDv-1m-HBY" firstAttribute="centerX" secondItem="ea4-BJ-QpY" secondAttribute="centerX" id="it4-ej-Yhp"/>
                                         </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="JQq-28-X2x">
-                                        <rect key="frame" x="536" y="0.0" width="94" height="156"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="DgK-dR-XUe">
+                                        <rect key="frame" x="500" y="0.0" width="94" height="164"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                                <rect key="frame" x="9.6666666666666288" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                                <rect key="frame" x="40.333333333333371" y="90.666666666666657" width="13.333333333333336" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="94.666666666666657" width="94" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                                <rect key="frame" x="0.0" y="124" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="132" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="mangoStepperChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="vwl-SG-3dE"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
-                                            <constraint firstAttribute="width" secondItem="JQq-28-X2x" secondAttribute="height" multiplier="47:78" id="0VH-Ov-khI"/>
+                                            <constraint firstItem="w1F-9o-qJR" firstAttribute="centerX" secondItem="DgK-dR-XUe" secondAttribute="centerX" id="0Dz-hA-KEc"/>
+                                            <constraint firstItem="xbn-6P-grO" firstAttribute="width" secondItem="w1F-9o-qJR" secondAttribute="width" id="CYm-vx-Ldm"/>
+                                            <constraint firstItem="YJI-ER-LJR" firstAttribute="centerX" secondItem="DgK-dR-XUe" secondAttribute="centerX" id="EhI-Ub-RrF"/>
+                                            <constraint firstItem="YJI-ER-LJR" firstAttribute="width" secondItem="w1F-9o-qJR" secondAttribute="width" id="edB-Or-u4K"/>
+                                            <constraint firstItem="xbn-6P-grO" firstAttribute="centerX" secondItem="DgK-dR-XUe" secondAttribute="centerX" id="hTu-PJ-Gfe"/>
                                         </constraints>
                                     </stackView>
                                 </subviews>
@@ -443,38 +485,54 @@
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="FoF-R4-2Xz" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="MQG-j5-THL"/>
-                            <constraint firstItem="FoF-R4-2Xz" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="fqI-H0-9oK"/>
+                            <constraint firstItem="maT-a4-Oji" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="HUM-EV-QaV"/>
+                            <constraint firstItem="maT-a4-Oji" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="aSg-ch-EeD"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
+                    <toolbarItems/>
+                    <navigationItem key="navigationItem" title="재고관리" id="3qj-70-fMX">
+                        <barButtonItem key="rightBarButtonItem" title="완료" id="gd9-XI-fM1" userLabel="이거 버튼">
+                            <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <connections>
+                                <action selector="completeButton:" destination="Yu1-lM-nqp" id="aDu-ao-ynE"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
+                    <connections>
+                        <outlet property="bananaStockLabel" destination="gKu-86-RhI" id="VJb-hO-DpK"/>
+                        <outlet property="bananaStockStepper" destination="O5s-2N-3iP" id="ZHE-KX-AkG"/>
+                        <outlet property="kiwiStockLabel" destination="ZDv-1m-HBY" id="831-hX-rgJ"/>
+                        <outlet property="kiwiStockStepper" destination="klA-59-Nu4" id="Ivd-QK-hhb"/>
+                        <outlet property="mangoStockLabel" destination="YJI-ER-LJR" id="coE-JP-qXj"/>
+                        <outlet property="mangoStockStepper" destination="xbn-6P-grO" id="V4o-Um-V0y"/>
+                        <outlet property="pineappleStockLabel" destination="MpT-VW-hCb" id="mx9-uY-IvI"/>
+                        <outlet property="pineappleStockStepper" destination="Rcr-xr-eqz" id="y25-Fe-F31"/>
+                        <outlet property="strawberryStockLabel" destination="0yV-kn-zaT" id="uqe-ZP-qQR"/>
+                        <outlet property="strawberryStockStepper" destination="ZQk-f4-zrz" id="0XY-Xp-anY"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1636.4928909952605" y="900"/>
+            <point key="canvasLocation" x="1783" y="1056"/>
         </scene>
         <!--Navigation Controller-->
-        <scene sceneID="cAf-jL-tPK">
+        <scene sceneID="xdf-sA-l9Z">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
-                    <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="44"/>
+                <navigationController id="q60-yX-nlV" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="2Ah-QL-Eik">
+                        <rect key="frame" x="0.0" y="0.0" width="926" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
-                    <nil name="viewControllers"/>
                     <connections>
-                        <segue destination="Yu1-lM-nqp" kind="relationship" relationship="rootViewController" id="wH1-3A-cBm"/>
+                        <segue destination="Yu1-lM-nqp" kind="relationship" relationship="rootViewController" id="Mc2-Rg-jAB"/>
                     </connections>
                 </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="2s5-lS-967" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Q82-46-TZk" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1637" y="21"/>
+            <point key="canvasLocation" x="1783" y="156"/>
         </scene>
     </scenes>
-    <inferredMetricsTieBreakers>
-        <segue reference="z67-rM-F6w"/>
-    </inferredMetricsTieBreakers>
     <resources>
         <image name="Bab" width="512" height="512"/>
         <image name="miniBanana 1" width="450" height="500"/>
@@ -486,7 +544,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGray5Color">
-            <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
# 쥬스 자판기 [STEP 3] 앤,샘

## 소개
안녕하세요,

주스 메이커 앱의 사용자 경험을 향상시키기 위해 재고 관리 기능과 사용자 인터페이스를 개선했습니다. 아래는 주요 변경 사항입니다.

## 주요 변경 사항

1. **Delegate 패턴 구현**: `SecondViewController`에서 재고를 업데이트한 후 `ViewController`로 돌아올 때 재고 레이블이 자동으로 업데이트됩니다.
2. **재고 관리 UI 개선**: 각 과일별 재고 수량을 보여주는 레이블과 스테퍼를 추가하여 사용자가 쉽게 재고를 관리할 수 있도록 했습니다.
3. **주스 주문 로직 개선**: 주스를 주문할 때, 재고가 충분한지 확인하고, 부족할 경우 사용자에게 알림을 표시합니다.
4. **코드 리팩토링**: 불필요한 주석 제거 및 코드 구조를 개선했습니다.

## 스크린샷
![simulator_screenshot_FD9B65A4-C3FE-46D8-884B-B7DBAB0CD963](https://github.com/tasty-code/ios-juice-maker/assets/75471842/ac1d9fa4-a9f8-49d0-968a-e70861e884cb)
![simulator_screenshot_15FB5F8B-8B21-4AB0-A979-7886CAA35C4B](https://github.com/tasty-code/ios-juice-maker/assets/75471842/4ef6de00-f3bb-4aa8-a8c5-a37c81989e54)

## 시연영상
![화면-기록-2023-12-22-오후-5 29 02](https://github.com/tasty-code/ios-juice-maker/assets/75471842/5444c8b6-b651-4978-ba7b-5c2334768d3e)
![화면-기록-2023-12-22-오후-5 29 36](https://github.com/tasty-code/ios-juice-maker/assets/75471842/1b5a323d-7189-424f-826a-4458c575009f)




## 테스트

- 모든 과일의 재고를 업데이트하고, 해당 재고가 정확하게 반영되는지 확인했습니다.
- 주스 주문 시, 재고가 부족할 경우 알림이 표시되는지 확인했습니다.
- 앱의 전반적인 사용성을 테스트하여 버그가 없는지 확인했습니다.

## 피드백 요청

리뷰 부탁드리며, 추가적인 개선 사항이나 의견이 있으시면 알려주세요!

감사합니다.